### PR TITLE
feat: add fan speed control via webhooks/CLI

### DIFF
--- a/Itsyhome/Shared/URLSchemeHandler.swift
+++ b/Itsyhome/Shared/URLSchemeHandler.swift
@@ -50,6 +50,9 @@ enum URLSchemeHandler {
         case "color":
             return parseColorAction(components: components)
 
+        case "speed":
+            return parseValueAction("speed", components: components)
+
         case "scene":
             return parseSceneAction(components: components)
 

--- a/macOSBridge/ActionEngine/ActionEngine.swift
+++ b/macOSBridge/ActionEngine/ActionEngine.swift
@@ -25,6 +25,9 @@ enum Action: Equatable {
     // Position (blinds, 0-100)
     case setPosition(Int)
 
+    // Fan speed (0-100)
+    case setSpeed(Int)
+
     // Thermostat
     case setTargetTemp(Double)
     case setMode(ThermostatMode)
@@ -179,6 +182,8 @@ class ActionEngine {
             return executeColorTemp(mired, on: service, bridge: bridge)
         case .setPosition(let value):
             return executePosition(value, on: service, bridge: bridge)
+        case .setSpeed(let value):
+            return executeSpeed(value, on: service, bridge: bridge)
         case .setTargetTemp(let temp):
             return executeTargetTemp(temp, on: service, bridge: bridge)
         case .setMode(let mode):
@@ -316,6 +321,21 @@ class ActionEngine {
             return false
         }
         let clampedValue = max(0, min(100, value))
+        bridge.writeCharacteristic(identifier: id, value: clampedValue)
+        return true
+    }
+
+    private func executeSpeed(_ value: Int, on service: ServiceData, bridge: Mac2iOS) -> Bool {
+        guard let idString = service.rotationSpeedId, let id = UUID(uuidString: idString) else {
+            return false
+        }
+        var clampedValue = max(0, min(100, value))
+        if let minSpeed = service.rotationSpeedMin {
+            clampedValue = max(Int(minSpeed), clampedValue)
+        }
+        if let maxSpeed = service.rotationSpeedMax {
+            clampedValue = min(Int(maxSpeed), clampedValue)
+        }
         bridge.writeCharacteristic(identifier: id, value: clampedValue)
         return true
     }

--- a/macOSBridge/ActionEngine/ActionParser.swift
+++ b/macOSBridge/ActionEngine/ActionParser.swift
@@ -150,6 +150,9 @@ enum ActionParser {
         case "mode":
             return parseModeCommand(tokens: tokens)
 
+        case "speed":
+            return parseSpeedCommand(tokens: tokens)
+
         default:
             return .failure(.unknownAction("set \(property)"))
         }
@@ -253,6 +256,20 @@ enum ActionParser {
 
         let target = tokens.dropFirst(3).joined(separator: " ")
         return .success(ParsedCommand(target: target, action: .setMode(mode)))
+    }
+
+    private static func parseSpeedCommand(tokens: [String]) -> Result<ParsedCommand, ParseError> {
+        // "set speed 50 bedroom fan"
+        guard tokens.count >= 4 else {
+            return .failure(.missingTarget)
+        }
+
+        guard let value = Int(tokens[2]), value >= 0, value <= 100 else {
+            return .failure(.invalidValue(tokens[2]))
+        }
+
+        let target = tokens.dropFirst(3).joined(separator: " ")
+        return .success(ParsedCommand(target: target, action: .setSpeed(value)))
     }
 
     private static func parseSceneCommand(tokens: [String]) -> Result<ParsedCommand, ParseError> {


### PR DESCRIPTION
## Summary

Adds fan speed control through webhooks and URL schemes, bringing fan control in line with other percentage-based controls like brightness and position.

## Changes

### ActionEngine.swift
- Added `case setSpeed(Int)` to the `Action` enum
- Added `executeSpeed()` function using `service.rotationSpeedId`
- Respects `rotationSpeedMin`/`rotationSpeedMax` limits when set by the device

### ActionParser.swift  
- Added `speed` case in `parseSetCommand` switch
- Added `parseSpeedCommand()` function for parsing `set speed <value> <target>`

### URLSchemeHandler.swift
- Added `speed` case using existing `parseValueAction()` helper

## Usage

```bash
# Webhook
curl http://localhost:8423/speed/50/Bedroom/Ceiling%20Fan

# URL scheme  
open "itsyhome://speed/50/Bedroom/Ceiling Fan"

# Command (via ActionParser)
set speed 50 Bedroom/Ceiling Fan
```

## Notes

- CLI support (`itsyhome speed 50 Room/Fan`) would require a one-line addition to the [itsyhome-cli](https://github.com/nickustinov/itsyhome-cli) repo:
  ```go
  rootCmd.AddCommand(makeValueControlCmd("speed", "Set fan speed (0-100)", "value"))
  ```

- The `rotationSpeedId` characteristic was already being read for state display; this PR wires up the write path.

Thanks for a great app! 🏠