### PR TITLE
Fix brew install command in Settings

### DIFF
--- a/macOSBridge/Settings/Sections/WebhooksSection.swift
+++ b/macOSBridge/Settings/Sections/WebhooksSection.swift
@@ -136,7 +136,7 @@ class WebhooksSection: SettingsCard {
         stackView.addArrangedSubview(createSpacer(height: 8))
 
         // CLI tip
-        let tipLabel = createLabel("Install CLI: brew install itsyhome — then run itsyhome config to connect.", style: .caption)
+        let tipLabel = createLabel("Install CLI: brew install nickustinov/tap/itsyhome — then run itsyhome config to connect.", style: .caption)
         tipLabel.textColor = .tertiaryLabelColor
         stackView.addArrangedSubview(tipLabel)
 


### PR DESCRIPTION
Fixes #77

Changes the incorrect command `brew install itsyhome` to the correct `brew install nickustinov/tap/itsyhome` in the Settings window CLI tip.

**Changed:**
- Line 139 in WebhooksSection.swift: Updated CLI tip to show correct brew command

**Note:** Line 61 in the description already had the correct command - only the bottom tip needed fixing.