### PR TITLE
Virtual HomeKit sensors and Automations

### DIFF
--- a/Itsyhome.xcodeproj/project.pbxproj
+++ b/Itsyhome.xcodeproj/project.pbxproj
@@ -2502,6 +2502,7 @@
 		B9A8B0AD26D9497CA3C7993A /* ph.pause-circle.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 92FB43735AEEAF6D1BEA6D59 /* ph.pause-circle.fill.svg */; };
 		B9C06704C95E4DB8C723A79F /* ph.thermometer-cold.svg in Resources */ = {isa = PBXBuildFile; fileRef = ED744CD65393A4C79C363396 /* ph.thermometer-cold.svg */; };
 		B9C236BE236DA20D17F4386F /* ph.wifi-low.svg in Resources */ = {isa = PBXBuildFile; fileRef = 85980112647A924644D322E3 /* ph.wifi-low.svg */; };
+		B9DDE6B4B8A4E09969F04BB7 /* HAPIdentityKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28E4C41865A4B7D148863FD /* HAPIdentityKeychain.swift */; };
 		B9EF3D2A55A83732857C3102 /* ph.vignette.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = CAD2AA6351BC0E49135EBC1C /* ph.vignette.fill.svg */; };
 		B9F18BADD10D23BB41580BC4 /* ph.clover.svg in Resources */ = {isa = PBXBuildFile; fileRef = FD16BBF84484FD6F857C241D /* ph.clover.svg */; };
 		B9F4E511D881DC83ECE6F623 /* ph.lock-key.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = E3BA71ADA0D2D3FE82D0F718 /* ph.lock-key.fill.svg */; };
@@ -2584,6 +2585,7 @@
 		C0728FE2E813EB59E3773E10 /* ph.waveform.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 357E9A799F75061FD85787FE /* ph.waveform.fill.svg */; };
 		C0971C587D9BBA1025551C8D /* ph.key.svg in Resources */ = {isa = PBXBuildFile; fileRef = 695B6A50DE1B5F0775CDDECF /* ph.key.svg */; };
 		C0C0F5F4260A6F59906A99B0 /* ph.sneaker-move.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 3FAA5BE535E749BB5A72F10B /* ph.sneaker-move.fill.svg */; };
+		C0E51245A7FAAD3DD50D685B /* HAPIdentityKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28E4C41865A4B7D148863FD /* HAPIdentityKeychain.swift */; };
 		C0F1597B4185D92A5E5E45CF /* ph.eye-closed.svg in Resources */ = {isa = PBXBuildFile; fileRef = 54AAEAD20351AE9C05C4111A /* ph.eye-closed.svg */; };
 		C0FA76AC5F8A38B45504475D /* ph.eyeglasses.svg in Resources */ = {isa = PBXBuildFile; fileRef = EEE18BE58BA40A98CEDA5B0B /* ph.eyeglasses.svg */; };
 		C0FBCA0C7321118963C3CF5A /* ph.folder-simple-lock.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = B134BBCB34F7FAF9CC2664EC /* ph.folder-simple-lock.fill.svg */; };
@@ -6526,6 +6528,7 @@
 		F27AD71D12106F736B139E74 /* ph.cell-signal-none.svg */ = {isa = PBXFileReference; path = "ph.cell-signal-none.svg"; sourceTree = "<group>"; };
 		F27C6A4E49237FAA46F67C9D /* ph.user-minus.svg */ = {isa = PBXFileReference; path = "ph.user-minus.svg"; sourceTree = "<group>"; };
 		F2888D61E3A08217856C6E70 /* ph.washing-machine.svg */ = {isa = PBXFileReference; path = "ph.washing-machine.svg"; sourceTree = "<group>"; };
+		F28E4C41865A4B7D148863FD /* HAPIdentityKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAPIdentityKeychain.swift; sourceTree = "<group>"; };
 		F29411290B0D98B4C75C9318 /* ph.pentagon.fill.svg */ = {isa = PBXFileReference; path = ph.pentagon.fill.svg; sourceTree = "<group>"; };
 		F2B85C529AD6481D7F63F119 /* ph.grains-slash.fill.svg */ = {isa = PBXFileReference; path = "ph.grains-slash.fill.svg"; sourceTree = "<group>"; };
 		F2BB059BF1F54562487FE8D2 /* ModeButtonGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModeButtonGroup.swift; sourceTree = "<group>"; };
@@ -6923,6 +6926,7 @@
 			isa = PBXGroup;
 			children = (
 				C74106EAB1CEB975E6B3DFCC /* FilePairingStore.swift */,
+				F28E4C41865A4B7D148863FD /* HAPIdentityKeychain.swift */,
 				1BC9BB856B1F21EB05CC6737 /* HAPService+CarbonDioxide.swift */,
 				8E912B10122DBDD307334052 /* VirtualBridgeService.swift */,
 				6C324A49E5DE7383B3116A5A /* VirtualControl.swift */,
@@ -13544,6 +13548,7 @@
 				C75447EACE1D4BE50218DB35 /* HAHumidifierMenuItem.swift in Sources */,
 				6A08A1E13F3F2DEB3D28188C /* HALockMenuItem.swift in Sources */,
 				D3C658BC3BB56C1E309511C1 /* HAModels.swift in Sources */,
+				B9DDE6B4B8A4E09969F04BB7 /* HAPIdentityKeychain.swift in Sources */,
 				A997078001F9A7A84D60684A /* HAPService+CarbonDioxide.swift in Sources */,
 				E36468EF65BF34164C05B424 /* HASecuritySystemMenuItem.swift in Sources */,
 				DCA1F3C588948A0CA6DF932D /* HASuccessWindowController.swift in Sources */,
@@ -13701,6 +13706,7 @@
 				8FFE17F91B99FCB47BCB29D0 /* HAModels.swift in Sources */,
 				DF2EA2565247431E445B32EE /* HAModelsTests.swift in Sources */,
 				134E7F2B048EE730C61E1506 /* HAPCarbonDioxideTests.swift in Sources */,
+				C0E51245A7FAAD3DD50D685B /* HAPIdentityKeychain.swift in Sources */,
 				5860C2828B56E3A5CB0E557B /* HAPService+CarbonDioxide.swift in Sources */,
 				BAD9A04129591C3A9C0E47AB /* HASecuritySystemMenuItem.swift in Sources */,
 				AD4D681D6C6471E0B10CB188 /* HASuccessWindowController.swift in Sources */,
@@ -14120,8 +14126,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mikeburgh/hap-swift.git";
 			requirement = {
-				branch = macos14;
-				kind = branch;
+				kind = revision;
+				revision = 6e62417d61522823552417714b62af89b2e211b3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Itsyhome.xcodeproj/project.pbxproj
+++ b/Itsyhome.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		0614CAD3EBA19625AF0ACB5A /* ph.sign-in.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 5568403E2983DD8201F73DB2 /* ph.sign-in.fill.svg */; };
 		061ED3A7F03E627F6D6D551D /* ph.number-square-four.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = DB7046C1BD0F9267A1220F69 /* ph.number-square-four.fill.svg */; };
 		063B4DE9C9A7887E25154630 /* ph.sliders-horizontal.svg in Resources */ = {isa = PBXBuildFile; fileRef = D824278C9FE2993414C27311 /* ph.sliders-horizontal.svg */; };
+		06563D2DCDD0D3B3AB999B7E /* AutomationDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD708B8E691F4265A280899F /* AutomationDraft.swift */; };
 		069B3B0D33FB7434CEB1B2CE /* ph.chalkboard-simple.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8EF48C8D69495899691F3690 /* ph.chalkboard-simple.fill.svg */; };
 		069D686EF497B4BE291ED8F9 /* ValueConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1BB4554FA59FCE166E2B86 /* ValueConversionTests.swift */; };
 		06A09FD503B9F11D1C7C4509 /* ph.text-italic.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 3EC64A0FDF44BB8652781820 /* ph.text-italic.fill.svg */; };
@@ -104,6 +105,7 @@
 		076BD407FD712E0EA8CC5301 /* ph.phone-x.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = D5C511657E3CD7B288D2EBEE /* ph.phone-x.fill.svg */; };
 		077FEB94E3705298F76B6103 /* ph.smiley-melting.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = D7AD2D98C008C031C44A2F2F /* ph.smiley-melting.fill.svg */; };
 		07A302575F0F86237495D0A5 /* ph.coffee.svg in Resources */ = {isa = PBXBuildFile; fileRef = E5D6B6CEE729DBA4944090B7 /* ph.coffee.svg */; };
+		07E6AF5C498445C5FCD2E9F7 /* HAPSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 2083564DCF5AF576E19BCAD6 /* HAPSwift */; };
 		07ECCBA7F4459E3FB18DBE7D /* ph.equalizer.svg in Resources */ = {isa = PBXBuildFile; fileRef = 9FD30846D1E594A02FA40902 /* ph.equalizer.svg */; };
 		07F0155BB21510D30A7AEFB9 /* ph.folder-simple-plus.svg in Resources */ = {isa = PBXBuildFile; fileRef = 45D25F7496C835592B3F0E8D /* ph.folder-simple-plus.svg */; };
 		081C574CB84363FC0F49E0D1 /* ph.file-ini.svg in Resources */ = {isa = PBXBuildFile; fileRef = 053B298BE56428BA275AF898 /* ph.file-ini.svg */; };
@@ -117,6 +119,7 @@
 		08CE1E8768ACA7CA9BAD577F /* ph.coffee-bean.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = BB1BA20AC319B88D511094CD /* ph.coffee-bean.fill.svg */; };
 		08D8F3C60170681EF3187BCE /* ThermostatMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86C440D0DF207C3DF9F3A5AD /* ThermostatMenuItem.swift */; };
 		08E15B730686540071BF00F7 /* ph.git-merge.svg in Resources */ = {isa = PBXBuildFile; fileRef = 326DDB7FA7331759DB8B1C25 /* ph.git-merge.svg */; };
+		08E942B7ABD7F481779D182C /* VirtualControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C324A49E5DE7383B3116A5A /* VirtualControl.swift */; };
 		08EC3C548335566A7EE1CEDF /* ph.tip-jar.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6BE581FABE3E8AE46CC0A1A1 /* ph.tip-jar.svg */; };
 		0947EDCF1ABF81BE1DD957F1 /* ph.baby-carriage.svg in Resources */ = {isa = PBXBuildFile; fileRef = 77B8B4ECDB7711395D6A329D /* ph.baby-carriage.svg */; };
 		09483CFCBEE412A145801C3F /* ph.app-window.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6C87BAF10012B46DD3CE8B36 /* ph.app-window.fill.svg */; };
@@ -180,6 +183,7 @@
 		0CE4544820ED9FDA7BB1E645 /* ph.compass-rose.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 32402F58787D67D6058F074C /* ph.compass-rose.fill.svg */; };
 		0CFF84EF7AF7FAE0B614D108 /* ph.stool.svg in Resources */ = {isa = PBXBuildFile; fileRef = CCAD64F6FEF055C1B3ED32E7 /* ph.stool.svg */; };
 		0D1340AA633BF40EC7B797C4 /* SecuritySystemMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBD57CCBF703A5861D8AEFB0 /* SecuritySystemMenuItem.swift */; };
+		0D139D423FB3B430F5206105 /* AutomationEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = C803C5C3BD7362C8437F7658 /* AutomationEngine.swift */; };
 		0D345F04D29BC52946E40149 /* ph.arrow-up-right.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = FA8C762BFC95E00E6EBAF5E6 /* ph.arrow-up-right.fill.svg */; };
 		0D39F44AD690519C4D6AFE87 /* ph.ladder-simple.svg in Resources */ = {isa = PBXBuildFile; fileRef = 84FB1DA43F0D958B2BA4F8F7 /* ph.ladder-simple.svg */; };
 		0D4605C5CA172E7D1AB5CDBC /* GroupMenuItem+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFE4029922DF6D70348EF11 /* GroupMenuItem+Actions.swift */; };
@@ -254,6 +258,7 @@
 		12670C1BFCD394B61E6DE9D4 /* ph.caret-circle-double-left.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 88CA9FC1253FA282115D23D0 /* ph.caret-circle-double-left.fill.svg */; };
 		1280024E6D3AC03F6A1859F4 /* ph.book-open.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = B2337CFA0DF0590F1C0876FB /* ph.book-open.fill.svg */; };
 		1288731FB5172C39A4F6CC62 /* ph.person.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 884A1B956B93B1E2B0C84ED9 /* ph.person.fill.svg */; };
+		128A80B51C47332F17216C5D /* HAPApple in Frameworks */ = {isa = PBXBuildFile; productRef = 07C3EEE5DFEF1156CC03B2FE /* HAPApple */; };
 		129812CA03721A0FF40B4DCE /* ph.arrows-out-line-vertical.svg in Resources */ = {isa = PBXBuildFile; fileRef = A9052600E3456EF44CF83721 /* ph.arrows-out-line-vertical.svg */; };
 		12A6EC804682CDC7B106ED98 /* ph.sailboat.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 58B4BA1D418D1CEE8DE3DF01 /* ph.sailboat.fill.svg */; };
 		12A755E1A73B4DA30DCAFD9C /* ph.user-circle-gear.svg in Resources */ = {isa = PBXBuildFile; fileRef = C3160F783ED5FDEB0724AD8D /* ph.user-circle-gear.svg */; };
@@ -262,6 +267,7 @@
 		12CF14BE0650614E2A1E1BDF /* ph.medium-logo.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = A37C40555927250BD3965C64 /* ph.medium-logo.fill.svg */; };
 		12DB61DE6E5DE7CB21A393DD /* ph.battery-warning.svg in Resources */ = {isa = PBXBuildFile; fileRef = 9E25074C469FDD82CB95B0DC /* ph.battery-warning.svg */; };
 		13236318334A338D80E0C741 /* WebhooksSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1443A561323B39B108F71E /* WebhooksSection.swift */; };
+		134E7F2B048EE730C61E1506 /* HAPCarbonDioxideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3961BC62634C9BBF8E78E1FA /* HAPCarbonDioxideTests.swift */; };
 		1352C3829F5391E50F21B5CC /* ph.orange-slice.svg in Resources */ = {isa = PBXBuildFile; fileRef = D1110E17B62056EFC4BCD1A8 /* ph.orange-slice.svg */; };
 		13736DAF6F660C482265B9FA /* GarageDoorMenuItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71887325832D4E805F89008F /* GarageDoorMenuItemTests.swift */; };
 		1375EE8324BBAFE69DA54BEB /* ph.person-arms-spread.svg in Resources */ = {isa = PBXBuildFile; fileRef = B60DB3EAAA5A9EBCC45CDFA1 /* ph.person-arms-spread.svg */; };
@@ -343,6 +349,7 @@
 		195ACF50870513FB2D24A52A /* ph.arrow-elbow-left-down.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 3B4DF592DFC3281622B8DD83 /* ph.arrow-elbow-left-down.fill.svg */; };
 		195D13796CEE808A123FF2F4 /* ph.scribble.svg in Resources */ = {isa = PBXBuildFile; fileRef = AD8B91927EF585E2C8B540F3 /* ph.scribble.svg */; };
 		196BC252EB4D4468183B9EE8 /* ph.arrows-in.svg in Resources */ = {isa = PBXBuildFile; fileRef = FE6A3D91018F8AEE88A638B5 /* ph.arrows-in.svg */; };
+		19715D949570E81028E1D58C /* HAPCore in Frameworks */ = {isa = PBXBuildFile; productRef = FC3CEBE6982A4F9F31F8E6E0 /* HAPCore */; };
 		198F793808AF6B48419FBB0D /* ph.tiktok-logo.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = C6DE112EDE665939C1FEF43C /* ph.tiktok-logo.fill.svg */; };
 		19A63DFF092704F771EB1FB9 /* ph.phone-transfer.svg in Resources */ = {isa = PBXBuildFile; fileRef = F23B4325F1F3CC5B4E8B01C8 /* ph.phone-transfer.svg */; };
 		19A771D4E91FA3F40691CE3D /* ph.user-circle-plus.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 10262F3BD4612E363078C00E /* ph.user-circle-plus.fill.svg */; };
@@ -427,6 +434,7 @@
 		1EF1B72B88B042471893F2AF /* ph.airplane-in-flight.svg in Resources */ = {isa = PBXBuildFile; fileRef = 75C964F75CE32B8E424B785B /* ph.airplane-in-flight.svg */; };
 		1EF9B037926ACCE5532C49FA /* ph.music-notes-simple.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 86AF9592BDA195923534C505 /* ph.music-notes-simple.fill.svg */; };
 		1F2C67DD8CCDFFD011C406FC /* ph.pi.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 5F7DDACEB46FCC61F2C0FD9A /* ph.pi.fill.svg */; };
+		1F34F501B6E0291D3BAD2404 /* AutomationBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07BA194642206C7A138BE4CB /* AutomationBuilderTests.swift */; };
 		1F3F167553112C17651DF3BA /* PreferencesManager+Ordering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F015059030FE61A6C4B4AE5 /* PreferencesManager+Ordering.swift */; };
 		1F40AE6DB3424BCC0EC82C42 /* URLSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A1A234EF733DB7475895AD /* URLSchemeHandler.swift */; };
 		1F4F0528DDD7759E7FC17BC4 /* ph.baseball-helmet.svg in Resources */ = {isa = PBXBuildFile; fileRef = 3033BB0094F4DA1E2BC5B2AB /* ph.baseball-helmet.svg */; };
@@ -445,6 +453,7 @@
 		202A20C55AD050252B088AE9 /* ph.chat-slash.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = CA686EE1F4664B0039F5D7DD /* ph.chat-slash.fill.svg */; };
 		202E2EAD1024D67600588D52 /* ph.puzzle-piece.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8C86C36F01F54C9130D06384 /* ph.puzzle-piece.svg */; };
 		203C1FC66D510FE10C206DCD /* ph.suitcase-simple.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 241FC4800D5116C3E48259E5 /* ph.suitcase-simple.fill.svg */; };
+		203F0C55192C081CCCC3DC07 /* PreferencesManager+VirtualBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C3F561C859455DA9F85580 /* PreferencesManager+VirtualBridge.swift */; };
 		2047D1D4E618E4B25670E73E /* ph.monitor-arrow-up.svg in Resources */ = {isa = PBXBuildFile; fileRef = 13E666DAE8F4B0E65C0795B0 /* ph.monitor-arrow-up.svg */; };
 		20535CA3FE8DB7661EDA924C /* ph.standard-definition.svg in Resources */ = {isa = PBXBuildFile; fileRef = 515F4E919CA04E32DF1AB929 /* ph.standard-definition.svg */; };
 		20B70980D560BEFF72E6F06A /* ph.share-network.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 704D6DC4B595E3B966DB4274 /* ph.share-network.fill.svg */; };
@@ -516,6 +525,7 @@
 		2611FB226856B7BA7A655B54 /* ph.fish.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 3207E7942C1276EC463AC9A1 /* ph.fish.fill.svg */; };
 		262DD6F1D95249E25F783789 /* ph.champagne.svg in Resources */ = {isa = PBXBuildFile; fileRef = DD9F05E47F3E84232380F1AA /* ph.champagne.svg */; };
 		262E7BF1D7EA42BF1129CDC3 /* IconResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1013245D5960DD38DB94DEE0 /* IconResolverTests.swift */; };
+		263B73AD98F09C7A5682555F /* Automation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1336E9251DBA9D947B18CD0 /* Automation.swift */; };
 		264168CEFA6B1E3697CCC195 /* ph.arrow-u-up-right.svg in Resources */ = {isa = PBXBuildFile; fileRef = 7DF4D64184E89344E95FC24E /* ph.arrow-u-up-right.svg */; };
 		265F71F60C58F504D05A271A /* ph.play-circle.svg in Resources */ = {isa = PBXBuildFile; fileRef = 018699C32A9AE46E34E7612F /* ph.play-circle.svg */; };
 		269191EA0F1E4F2B0FE1CD26 /* ph.campfire.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6E47734CA43935AE9C4B5179 /* ph.campfire.svg */; };
@@ -582,6 +592,7 @@
 		2B3329D963196604E0770F1D /* ph.sliders-horizontal.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = FFF950BFEF075CC2F9E9CA1C /* ph.sliders-horizontal.fill.svg */; };
 		2B5973612AE5AF4D3770A93A /* ph.device-mobile-camera.svg in Resources */ = {isa = PBXBuildFile; fileRef = A889CF99760A21CBC50311B6 /* ph.device-mobile-camera.svg */; };
 		2B6991C34FF862165FB81E22 /* ph.hand-soap.svg in Resources */ = {isa = PBXBuildFile; fileRef = 484D01FB3668ED03DE4EDEAF /* ph.hand-soap.svg */; };
+		2B6F71872A7D7828B70D079D /* VirtualSensorMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A031C11122F9992A94EB855 /* VirtualSensorMappingTests.swift */; };
 		2BB796FB81A2DD21068D2E8F /* ph.train-regional.svg in Resources */ = {isa = PBXBuildFile; fileRef = B0C0B1FAEA86CE690B28CE2F /* ph.train-regional.svg */; };
 		2BBEC61B3EBB21E495DB7BF5 /* ph.polygon.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = AB015BED592B3351296C83F6 /* ph.polygon.fill.svg */; };
 		2BC0C224A391D617793F96CD /* ColorPickerViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969ADECEBC8D55A1B08144AD /* ColorPickerViews.swift */; };
@@ -695,6 +706,7 @@
 		33B637EDB2AE4F2E8CA68D23 /* ph.graph.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = E6849A52B6A0BAC5221A3F6A /* ph.graph.fill.svg */; };
 		33D9C144A88BEE7C1D0C69CB /* ph.lightning-a.svg in Resources */ = {isa = PBXBuildFile; fileRef = C52E94901704F3FB2353019B /* ph.lightning-a.svg */; };
 		34062B47FFDAF00812BAC17E /* ph.umbrella-simple.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 5C47405F72B7D820A06BE25C /* ph.umbrella-simple.fill.svg */; };
+		3416A0842E7E4AF0082FB1CD /* AutomationEngineCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B90430D58295703FB84ED9 /* AutomationEngineCoreTests.swift */; };
 		344B6EE8D8E12FDE2C0A25BA /* ph.map-pin-simple-line.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 0F30DDAC5BE5128CE25648A2 /* ph.map-pin-simple-line.fill.svg */; };
 		3468ABB31915D39AF41D2621 /* ProProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF08A602DCF69DA079C553B /* ProProducts.swift */; };
 		346F59166D179D547C97A3A9 /* ph.code-block.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = AC0E226FEF0260CA146E11B5 /* ph.code-block.fill.svg */; };
@@ -776,6 +788,7 @@
 		3A3DE9018EE181BAC66D9D79 /* ph.arrow-elbow-left-up.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = BC1120DE898CD3AF7F5911D2 /* ph.arrow-elbow-left-up.fill.svg */; };
 		3A420885F1B0974DD5CAC0C8 /* ph.arrow-arc-right.svg in Resources */ = {isa = PBXBuildFile; fileRef = CD70E3C1B0B2D3FBB47D9112 /* ph.arrow-arc-right.svg */; };
 		3A449503FCAB580346424190 /* ph.trash-simple.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = A9BC77C00D1F6499B78955B8 /* ph.trash-simple.fill.svg */; };
+		3A55CDF7EDEEEB416A4361E1 /* AutomationEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = C803C5C3BD7362C8437F7658 /* AutomationEngine.swift */; };
 		3A62FA69BC398D4F7C15A807 /* ph.bell-slash.svg in Resources */ = {isa = PBXBuildFile; fileRef = FDB823A6936DBA3C2C318F68 /* ph.bell-slash.svg */; };
 		3A66615B3D5B52D01C5D6C5A /* ph.club.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 0325F4624CF0D79682C3ACF7 /* ph.club.fill.svg */; };
 		3A879AC055C539D542AEBF17 /* ph.folder.svg in Resources */ = {isa = PBXBuildFile; fileRef = 5EF5D84A3AFCBD99AF1512C1 /* ph.folder.svg */; };
@@ -908,6 +921,7 @@
 		44B8B1C20AFFF3CEE4345B92 /* ph.pentagon.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = F29411290B0D98B4C75C9318 /* ph.pentagon.fill.svg */; };
 		44EA934B354A12B4D46B1C8F /* ph.train-regional.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 952EAE4C1980E988A2E0E514 /* ph.train-regional.fill.svg */; };
 		450BFD675E3ED19444F640C0 /* ph.skip-back.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 4E37DBB432A920D977D84E1A /* ph.skip-back.fill.svg */; };
+		452A97B863515090E5E8F020 /* PreferencesManager+VirtualBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C3F561C859455DA9F85580 /* PreferencesManager+VirtualBridge.swift */; };
 		452C54AFFA24ECE35EF251B8 /* ph.approximate-equals.svg in Resources */ = {isa = PBXBuildFile; fileRef = D7D5DBF6DD2110D4A6A0DCAC /* ph.approximate-equals.svg */; };
 		453854B5E95266FAA57D8C0F /* ph.link.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 7FB890460E0508D01761529E /* ph.link.fill.svg */; };
 		4549785FA89701A2C85436B7 /* ph.images-square.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = EA78B4B5A62EB6A303516210 /* ph.images-square.fill.svg */; };
@@ -985,10 +999,13 @@
 		4A2D982F8373A0AB94EE5197 /* ph.circles-four.svg in Resources */ = {isa = PBXBuildFile; fileRef = 442F0522BAB7A6C45FA9A2F3 /* ph.circles-four.svg */; };
 		4A346D85BEFC4EE8BE474383 /* ph.cards.svg in Resources */ = {isa = PBXBuildFile; fileRef = 0CBE632B748E53B85A66539B /* ph.cards.svg */; };
 		4A491BE8AF7ED4DE5D61224C /* ph.flip-horizontal.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 21993716D2638A7EAE3785BD /* ph.flip-horizontal.fill.svg */; };
+		4A4DF6C23BEC47364E74F9BC /* VirtualDeviceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6573418A912EA33D229B9F /* VirtualDeviceStoreTests.swift */; };
 		4AA3B4AE25C30EBA808BB398 /* ph.radio.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 4DDD666A788BC58A2E041052 /* ph.radio.fill.svg */; };
+		4AA96EA09DFF724A521D31EF /* VirtualControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C324A49E5DE7383B3116A5A /* VirtualControl.swift */; };
 		4AAF5EA0ABDA2CC9A1ADE143 /* ph.arrow-bend-up-left.svg in Resources */ = {isa = PBXBuildFile; fileRef = BEA50F38DF8DC510A2C425D4 /* ph.arrow-bend-up-left.svg */; };
 		4AB4350AEAA21D05FC569932 /* ph.user-sound.svg in Resources */ = {isa = PBXBuildFile; fileRef = 297A9F686696C61ED61EE5D5 /* ph.user-sound.svg */; };
 		4ABFEB3C04E6425C22289907 /* ph.calendar-x.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = E710FBD5F32D0F7CAFADF3AA /* ph.calendar-x.fill.svg */; };
+		4AF93F5BC79FFC414056F3EA /* VirtualControlRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641ADB10E070C561BD4D95EB /* VirtualControlRoutingTests.swift */; };
 		4AFDC43F30ED76B63BFF14A4 /* ph.grains-slash.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = F2B85C529AD6481D7F63F119 /* ph.grains-slash.fill.svg */; };
 		4B0E145611A371F822735022 /* ph.onigiri.svg in Resources */ = {isa = PBXBuildFile; fileRef = E8F4CD244E8E0C222C424262 /* ph.onigiri.svg */; };
 		4B1A6AAAAC505B2541975282 /* WebRTCStreamClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2F71B5A8EA5B3176D9922D /* WebRTCStreamClient.swift */; };
@@ -1157,6 +1174,7 @@
 		5849F766E448782E2FF55579 /* ph.cable-car.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 56EE8108A0DD0B86149A6BA7 /* ph.cable-car.fill.svg */; };
 		584E6850289D0E59424B198D /* PlatformManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A914A839AA874ADE2D3CB8E5 /* PlatformManager.swift */; };
 		585B12E5E759B8062BFE7F33 /* ph.police-car.svg in Resources */ = {isa = PBXBuildFile; fileRef = 63CA54C172C80DBD0EC56201 /* ph.police-car.svg */; };
+		5860C2828B56E3A5CB0E557B /* HAPService+CarbonDioxide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BC9BB856B1F21EB05CC6737 /* HAPService+CarbonDioxide.swift */; };
 		5862D91E33B8CA9ACF752ACF /* ph.arrow-square-down.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = D4139CC43AD323DA7321C75E /* ph.arrow-square-down.fill.svg */; };
 		5882264FA3983D7E070B0BD0 /* ph.camera.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = FDD5AD99E2B7ACCA5396303D /* ph.camera.fill.svg */; };
 		5887E8FF84C6D10F5EB1A5C3 /* ph.lamp-pendant.svg in Resources */ = {isa = PBXBuildFile; fileRef = 97A272A7309C096EE22F723E /* ph.lamp-pendant.svg */; };
@@ -1189,6 +1207,7 @@
 		5A76FF10264CA46BC45E1856 /* ph.number-zero.svg in Resources */ = {isa = PBXBuildFile; fileRef = 788F6C48403F373E3F5CD5E7 /* ph.number-zero.svg */; };
 		5A93ED088C2B8DC500C77DEA /* ph.shower.svg in Resources */ = {isa = PBXBuildFile; fileRef = DC86EDBAA5EFDFC89ABC3DCE /* ph.shower.svg */; };
 		5A9758E7BA9A04941DBA831A /* ph.terminal.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 408CB4E7E84DB3A275E1AC9D /* ph.terminal.fill.svg */; };
+		5AA09932E737992329CBD3A0 /* VirtualBridgeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E912B10122DBDD307334052 /* VirtualBridgeService.swift */; };
 		5AA0B88B2BEAC66BDA4EF533 /* ph.test-tube.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 34629EFAA1C692E3FCBF6513 /* ph.test-tube.fill.svg */; };
 		5AC8577E27616E5B00B790E1 /* ph.paypal-logo.svg in Resources */ = {isa = PBXBuildFile; fileRef = 7C74C8D5F166A91A8785D81F /* ph.paypal-logo.svg */; };
 		5AD8F319DB8F8849DB620F6E /* ph.number-circle-zero.svg in Resources */ = {isa = PBXBuildFile; fileRef = 41BFE4BD460258A90A71B2A8 /* ph.number-circle-zero.svg */; };
@@ -1310,6 +1329,7 @@
 		6397E640F21A29D047A96E74 /* ph.repeat.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 150134D9E1B5E29E1804C2A9 /* ph.repeat.fill.svg */; };
 		63AA00C163B17C7DF80BE19C /* DeviceGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1078ED585A5ECE7DF0A569F6 /* DeviceGroup.swift */; };
 		63AD7F83F9146A4F062889E7 /* ph.chair.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6FC63A7EAFF9918E7CDE3DA4 /* ph.chair.svg */; };
+		63C90468615234BDAF63C8C0 /* AutomationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AECF02EEDE530E5A837268F /* AutomationStore.swift */; };
 		63DC70513B7CEDC65F932D16 /* ph.book-open-text.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 07F6CB7EDE9023C6447AEB4D /* ph.book-open-text.fill.svg */; };
 		63E1108B7F9C41F412736C78 /* ph.paint-brush-broad.svg in Resources */ = {isa = PBXBuildFile; fileRef = 928D2969409982AAFA488F1D /* ph.paint-brush-broad.svg */; };
 		63E13ED5F29C5E71061EBCF0 /* ph.shovel.svg in Resources */ = {isa = PBXBuildFile; fileRef = C06CA23756225EA754FF2EEC /* ph.shovel.svg */; };
@@ -1375,6 +1395,7 @@
 		6870C2FD692EE67128A8ED32 /* ph.alarm.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 614CA2F4C95763A913FE8D1C /* ph.alarm.fill.svg */; };
 		687969352D1283E37F80BB9B /* ph.git-diff.svg in Resources */ = {isa = PBXBuildFile; fileRef = D685D3D51513F75866E3E022 /* ph.git-diff.svg */; };
 		6898E8C9153768433C3EC150 /* ph.x.svg in Resources */ = {isa = PBXBuildFile; fileRef = B8D97A3C93B4AE321E247137 /* ph.x.svg */; };
+		6898FFF6A558555F887E9763 /* HAPApple in Frameworks */ = {isa = PBXBuildFile; productRef = 580B079BA4E63260A1B785F1 /* HAPApple */; };
 		689AF2719A578ED1562F6FE0 /* HLSStreamPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9CEB29C22EDD5350366905 /* HLSStreamPlayer.swift */; };
 		68AE180369CE5C15CE1FB8B2 /* ph.bird.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = FAFD838E16B72BE9A5C19895 /* ph.bird.fill.svg */; };
 		68C6380FA4F1B48EF0D99D00 /* ph.train-simple.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6EA4B81867F68D894440ED5D /* ph.train-simple.svg */; };
@@ -1473,6 +1494,7 @@
 		6EA9F27D59F9D79AA28D1C64 /* ph.unite.svg in Resources */ = {isa = PBXBuildFile; fileRef = 627B3FA6CB5307AD4527103D /* ph.unite.svg */; };
 		6ECD2A8E74161BA10E24C979 /* CloudSyncTranslatorTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BC522AE2A26BA136B9347B /* CloudSyncTranslatorTestHelpers.swift */; };
 		6EDEACFC39E0842C9937A923 /* ph.road-horizon.svg in Resources */ = {isa = PBXBuildFile; fileRef = 69352D64B389AE778BC4075B /* ph.road-horizon.svg */; };
+		6F14900723B76DA77378AB94 /* FilePairingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74106EAB1CEB975E6B3DFCC /* FilePairingStore.swift */; };
 		6F158BF2BDDFDCCEB4843BB9 /* PhosphorIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71F198924CC917731F11F541 /* PhosphorIcon.swift */; };
 		6F413B439BF2E9B8F1572305 /* ph.gear.svg in Resources */ = {isa = PBXBuildFile; fileRef = 71BEC42AAE96EACEB7AFA7D7 /* ph.gear.svg */; };
 		6F42F28032D023CF81397D09 /* ph.arrows-in-cardinal.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = EF11D4667A8D08ED3F9EC531 /* ph.arrows-in-cardinal.fill.svg */; };
@@ -1623,6 +1645,7 @@
 		7B72DBE8A2AC4130A9A2C2D5 /* NetworkAutoSwitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B014E69ABBED5CF37466EEA4 /* NetworkAutoSwitchTests.swift */; };
 		7B773C43C5117A04465A9A4C /* ph.door.svg in Resources */ = {isa = PBXBuildFile; fileRef = A690DAB6F4DA26F9D65605B1 /* ph.door.svg */; };
 		7B8DD9AECC4738022DC28B46 /* ph.snapchat-logo.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = E53477F0FD27D953F16ED5EB /* ph.snapchat-logo.fill.svg */; };
+		7B9EF3BF43FFC8C0B65965D6 /* VirtualBridgeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E912B10122DBDD307334052 /* VirtualBridgeService.swift */; };
 		7BA19EA1885D6C9578FB27B0 /* ph.stack-overflow-logo.svg in Resources */ = {isa = PBXBuildFile; fileRef = 2D17ABE17363737E66C5D058 /* ph.stack-overflow-logo.svg */; };
 		7BA305285892C83C02D68453 /* ph.gas-pump.svg in Resources */ = {isa = PBXBuildFile; fileRef = B1AEFFA3941303E4AB71A52E /* ph.gas-pump.svg */; };
 		7BB119B671B3D114D30396B0 /* DeviceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C2BA989A5E5FBD918CAD29 /* DeviceResolver.swift */; };
@@ -1858,6 +1881,7 @@
 		8C04FBE70D8BEFD2D3884625 /* ph.signature.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6A1D1F7A62B32BB68879B961 /* ph.signature.svg */; };
 		8C0D027EEB4E3922916B142E /* EntityMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0007F71A595FEBA792961DC /* EntityMapperTests.swift */; };
 		8C29F0BAF4E68EA794670FAC /* ph.arrow-bend-double-up-right.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 37F428FDA98F5D61115D0349 /* ph.arrow-bend-double-up-right.fill.svg */; };
+		8C2A7EC591961E7D7BE93FBD /* VirtualDeviceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B87FA3FF077C5FAC1C7D0DC /* VirtualDeviceStore.swift */; };
 		8C2CFAC08CE11CC2F6BB0DA2 /* ph.shopping-bag-open.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = FE250B2DDFBC60C177DA2C6C /* ph.shopping-bag-open.fill.svg */; };
 		8C38AFBDCEA774AAEEBE88B1 /* ph.arrows-merge.svg in Resources */ = {isa = PBXBuildFile; fileRef = 373811FEC7FD45C560A1FCD7 /* ph.arrows-merge.svg */; };
 		8C3E681075B63811860CD11B /* ph.open-ai-logo.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6ECEBE736A481E12600D76FB /* ph.open-ai-logo.svg */; };
@@ -2131,6 +2155,7 @@
 		A04CE9D6C6F4F48A3C7AAF50 /* ph.arrow-fat-lines-left.svg in Resources */ = {isa = PBXBuildFile; fileRef = E831AC382CAAFFE95C46B7FD /* ph.arrow-fat-lines-left.svg */; };
 		A074A9BC9B9EC72DB8674571 /* ph.dice-two.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 36EA69F281672C4BE79EFCE2 /* ph.dice-two.fill.svg */; };
 		A0771EAA3D547FA7FFE74DAA /* ph.graphics-card.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8893821C3F31EAA8DDDBD57D /* ph.graphics-card.fill.svg */; };
+		A08322396E64BD00FF43B146 /* AutomationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AECF02EEDE530E5A837268F /* AutomationStore.swift */; };
 		A0A48667E369FBB5C8A27904 /* ph.translate.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 24A0411337879446C48AEB8B /* ph.translate.fill.svg */; };
 		A0B696DB187E4BECFF0E8B2C /* ph.speedometer.svg in Resources */ = {isa = PBXBuildFile; fileRef = 094DADB10C0FF4FA5BB4984A /* ph.speedometer.svg */; };
 		A0CF06E5BF3122DECB4A4AF8 /* ph.bag.svg in Resources */ = {isa = PBXBuildFile; fileRef = C0B49BF8D0AA4D74BA174935 /* ph.bag.svg */; };
@@ -2171,6 +2196,7 @@
 		A3138F8B61B28F7070331CA7 /* ph.puzzle-piece.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = B36479D885D3D4218BC7D328 /* ph.puzzle-piece.fill.svg */; };
 		A32465D11B17DDC8004639B7 /* ph.cloud-x.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6DC6FE3D5A6ADFFF94786845 /* ph.cloud-x.fill.svg */; };
 		A3439FAB0E11E8ED571D937F /* ph.paint-bucket.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6F1E94EBCF35C2AA8C1DFB03 /* ph.paint-bucket.fill.svg */; };
+		A363229EA501E1013F3E7665 /* HomeKitBridgeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E14E1F8CBB9739D49528D6 /* HomeKitBridgeSection.swift */; };
 		A36C9D83C48A8851916AF82A /* ph.wrench.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8F1B9A02815578A3DECD3785 /* ph.wrench.svg */; };
 		A3763C02FA083ADFAE8AA069 /* ph.chat-centered-slash.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 76B253FF31C86720F58F79F5 /* ph.chat-centered-slash.fill.svg */; };
 		A38D83841EC44CE7AFEA5F10 /* ph.envelope-simple.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 16A97C9249DC7B0106609A28 /* ph.envelope-simple.fill.svg */; };
@@ -2247,6 +2273,7 @@
 		A957E24E359957F370E512A9 /* ph.hand.svg in Resources */ = {isa = PBXBuildFile; fileRef = E995D49DF3858E9BE6254CDA /* ph.hand.svg */; };
 		A9707A630B1CD818327AA4C0 /* ph.arrow-square-up.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = DB5551E9AE887838CDCF4A98 /* ph.arrow-square-up.fill.svg */; };
 		A987214D89FF2DBA4B96931C /* ph.gas-pump.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = AA70A4605DF478C0B341B30F /* ph.gas-pump.fill.svg */; };
+		A997078001F9A7A84D60684A /* HAPService+CarbonDioxide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BC9BB856B1F21EB05CC6737 /* HAPService+CarbonDioxide.swift */; };
 		A9A960E2A49E552E32936873 /* ph.handshake.svg in Resources */ = {isa = PBXBuildFile; fileRef = 592B28B1762B346B101A271D /* ph.handshake.svg */; };
 		A9BA41D517D97FB4170C894F /* ph.scan-smiley.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = B85477330E51DA6D64233C67 /* ph.scan-smiley.fill.svg */; };
 		A9BDB40A7775A9973D0BCC9E /* ph.file.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = E0F046656D4BDF25EBCE8907 /* ph.file.fill.svg */; };
@@ -2307,6 +2334,7 @@
 		AD8E2EAD19CFB11A3B7AF6A7 /* HomeAssistantPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A08DDD6D713CFFBAB645A2B /* HomeAssistantPlatform.swift */; };
 		AD9309D6ACB8D31388B42861 /* ph.arrow-line-left.svg in Resources */ = {isa = PBXBuildFile; fileRef = EE0670C79F9361F06E66F37E /* ph.arrow-line-left.svg */; };
 		AD9481FF14C9C1A6554663B1 /* ValueConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46EB6A2D48574EFA0940AA54 /* ValueConversion.swift */; };
+		AD9577C4B5B972D6138BED64 /* VirtualBridgeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14BD2126C3CAD63117C643AF /* VirtualBridgeServiceTests.swift */; };
 		ADAEEFD46A7871933BAB1707 /* ph.bookmark-simple.svg in Resources */ = {isa = PBXBuildFile; fileRef = E12EC3DAAADE0129F61022A0 /* ph.bookmark-simple.svg */; };
 		ADD30900D5713D5480E1C742 /* ph.mouse-middle-click.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 2EE86F757DD4A95E7093C3D3 /* ph.mouse-middle-click.fill.svg */; };
 		ADE1CDE801F9C430F7CBE9E8 /* ph.corners-in.svg in Resources */ = {isa = PBXBuildFile; fileRef = 9FD883853EDDDE051F00E7A7 /* ph.corners-in.svg */; };
@@ -2369,6 +2397,8 @@
 		B2073E1E1855BAC5691F30B1 /* ph.phone-slash.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 4CCF9CC032A4E715F4F67D33 /* ph.phone-slash.fill.svg */; };
 		B228969CB3824F1195D6CEA9 /* ph.plus-circle.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 03D8F15315E2C1A5F457A52E /* ph.plus-circle.fill.svg */; };
 		B236B3156A0818EE8ADE48A8 /* ph.game-controller.svg in Resources */ = {isa = PBXBuildFile; fileRef = D7FCEEE44F61A58B6975DF76 /* ph.game-controller.svg */; };
+		B241F2942A1E9EAC5AE5E314 /* HAPSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A726444284976417DEF72286 /* HAPSwift */; };
+		B249DC3DA0DB85D2E667C678 /* VirtualDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE3BCEF7D494D0692CB50AB /* VirtualDevice.swift */; };
 		B25B2DF9541E13F777D699B3 /* ph.dots-six-vertical.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = CA387411A3036A21CB8428CD /* ph.dots-six-vertical.fill.svg */; };
 		B29D064CFB377BF9A6536281 /* ph.baseball.svg in Resources */ = {isa = PBXBuildFile; fileRef = 31736C5D95D30A0F751CD40A /* ph.baseball.svg */; };
 		B2A0429C8396EBB99764791A /* ph.arrow-elbow-right-down.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 4E5654A4CCA0355BA9F34739 /* ph.arrow-elbow-right-down.fill.svg */; };
@@ -2379,6 +2409,7 @@
 		B2EDB534F2D9272CE95D85BD /* ph.list.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 1B418704850694D58971D347 /* ph.list.fill.svg */; };
 		B3124CE6F3143C32E6BD101B /* ph.smiley-blank.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 2E9CC62A0F04BBB7C64185AE /* ph.smiley-blank.fill.svg */; };
 		B320C0D1ADF0E4CF425FEFCE /* ph.text-indent.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 58BA69991A6619B588C7AFF8 /* ph.text-indent.fill.svg */; };
+		B324755A68272ADECD3E2882 /* VirtualDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985376E03F8018247B75B845 /* VirtualDeviceTests.swift */; };
 		B326A3BD59C477F5335A4609 /* ph.device-mobile-slash.svg in Resources */ = {isa = PBXBuildFile; fileRef = 08647E90500C74B05F5D61BA /* ph.device-mobile-slash.svg */; };
 		B34B2C895E07B1399D701903 /* ph.tree-palm.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 82E4FA45A2A1B3CF6CBF0144 /* ph.tree-palm.fill.svg */; };
 		B363C7A0E7C1FA3F63D54E06 /* ph.tornado.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 79FF766F42F9C75AADB56D2B /* ph.tornado.fill.svg */; };
@@ -2420,6 +2451,7 @@
 		B6612DF2755746951B44A6DD /* ph.cloud-x.svg in Resources */ = {isa = PBXBuildFile; fileRef = E6E2A7E4AED6EA8A14A16576 /* ph.cloud-x.svg */; };
 		B67717A875CD46BAB68EF0A7 /* ph.minus.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 99AB458122D72CD812D7CAD2 /* ph.minus.fill.svg */; };
 		B690365DE2290E96C3B61B6D /* ph.butterfly.svg in Resources */ = {isa = PBXBuildFile; fileRef = BB107817699B68B91137B022 /* ph.butterfly.svg */; };
+		B6992A1E3C19774531C6BCEA /* VirtualDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE3BCEF7D494D0692CB50AB /* VirtualDevice.swift */; };
 		B6D4650869D280F2B783BEC4 /* ph.files.svg in Resources */ = {isa = PBXBuildFile; fileRef = 55E980800CEB2610769ECCA0 /* ph.files.svg */; };
 		B6E0BA859343F2AC750C12D5 /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DAE0D0C65A8D06C17611F3 /* HotkeyManager.swift */; };
 		B6EB103C6282C4822A77F652 /* ph.arrows-out-simple.svg in Resources */ = {isa = PBXBuildFile; fileRef = 63BD74E1A93D99B5A9A41555 /* ph.arrows-out-simple.svg */; };
@@ -2446,6 +2478,7 @@
 		B81FB504399AF2EF522FF36B /* ph.arrow-square-out.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6CF975DA8B730265512A03FE /* ph.arrow-square-out.svg */; };
 		B85116FDB39B3492F5F7B9F8 /* ph.selection-foreground.svg in Resources */ = {isa = PBXBuildFile; fileRef = C458D9580BF764B43E936333 /* ph.selection-foreground.svg */; };
 		B8571F7697B1DD385E1724E8 /* ph.file-cloud.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = F0C3AAE2E84FFDAEED525CE7 /* ph.file-cloud.fill.svg */; };
+		B884D90C7F075400509E75CA /* VirtualDeviceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B87FA3FF077C5FAC1C7D0DC /* VirtualDeviceStore.swift */; };
 		B8943C6757DEBB63CEC81BC3 /* SecurityIcons in Resources */ = {isa = PBXBuildFile; fileRef = 38A3F8628F6A8DE017FA09F5 /* SecurityIcons */; };
 		B8A535AD4BA43FE47DC71C60 /* ph.align-bottom.svg in Resources */ = {isa = PBXBuildFile; fileRef = 520E2FE57C9B5311588F2C0E /* ph.align-bottom.svg */; };
 		B8AA6A4DFFBEC4894ACB2932 /* ph.spiral.svg in Resources */ = {isa = PBXBuildFile; fileRef = 7289425AC801B4D017006B7A /* ph.spiral.svg */; };
@@ -2495,6 +2528,7 @@
 		BB7FDCE05F08236B8C412536 /* ph.playlist.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 5666624CB561F21A83647133 /* ph.playlist.fill.svg */; };
 		BB8D0BB59EFF890109FD70E5 /* ph.arrow-line-up.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = F4261B19D18C8B8827C96AE5 /* ph.arrow-line-up.fill.svg */; };
 		BBAFE01116F60E5293E54DD8 /* ph.microsoft-teams-logo.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = F4A59A176F2B7EA1CAD7F311 /* ph.microsoft-teams-logo.fill.svg */; };
+		BBD098B4DA5343FA9785BB5A /* FilePairingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74106EAB1CEB975E6B3DFCC /* FilePairingStore.swift */; };
 		BBDCB7F66788C0CBAD5D49C2 /* ph.ny-times-logo.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = E936E9F9130DED64A3CBC139 /* ph.ny-times-logo.fill.svg */; };
 		BBDE04FE4B95A05157057134 /* ph.drop-half-bottom.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 46982E17A955146780BB5384 /* ph.drop-half-bottom.fill.svg */; };
 		BC18FC26A00B6D7E9D7D3575 /* ActionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6B3519AD69969925F8F105 /* ActionEngine.swift */; };
@@ -2560,6 +2594,7 @@
 		C115DFFE1DCBEFF29D21D09A /* ph.text-aa.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = A85CCFECBFB7DEBA46AD78EB /* ph.text-aa.fill.svg */; };
 		C128F64D517E3C32E86CD92A /* ph.trend-down.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8BFD6AA0BADB44B61C13737D /* ph.trend-down.fill.svg */; };
 		C13F1F107F9FC7928B2A1CA8 /* ph.cheers.svg in Resources */ = {isa = PBXBuildFile; fileRef = 865647790AED58A91BAE43E9 /* ph.cheers.svg */; };
+		C14BD02B97B773817D81A387 /* AutomationEngineRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06560FD288CA69608EE122E /* AutomationEngineRuntimeTests.swift */; };
 		C14CA2D7DA005C5A95C590B1 /* ph.numpad.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = D3E094645F1768C5EAE0EF41 /* ph.numpad.fill.svg */; };
 		C1872886D488F26EAB29EF5E /* ph.person-simple-throw.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = EE5CD964EF1FAA0B66244ED3 /* ph.person-simple-throw.fill.svg */; };
 		C19A3650BAA8E3532335894C /* night.png in Resources */ = {isa = PBXBuildFile; fileRef = 72A6D02383082352635F077C /* night.png */; };
@@ -2973,6 +3008,7 @@
 		E0221D9F21C39ADF35C36D37 /* ph.map-trifold.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 52195F6FA6EAA0A2AF8E696D /* ph.map-trifold.fill.svg */; };
 		E0249E15C31BA80658E3A1E2 /* ph.caret-line-up.svg in Resources */ = {isa = PBXBuildFile; fileRef = 0CCEDB4C58985D89DE28D71B /* ph.caret-line-up.svg */; };
 		E044E507EC7EFC6895F60737 /* ph.align-center-horizontal.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = D0AB72DCDAA64885B7295217 /* ph.align-center-horizontal.fill.svg */; };
+		E051DA42EAC20884A09CC995 /* Automation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1336E9251DBA9D947B18CD0 /* Automation.swift */; };
 		E063FD13F2834BD3FCF2AE79 /* ph.first-aid.svg in Resources */ = {isa = PBXBuildFile; fileRef = 67B53CE04D8292081DF3F07A /* ph.first-aid.svg */; };
 		E069FD248C0FE4DEB0BC49AC /* ph.chat-teardrop.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 9482D94F52A3789B06E99F0F /* ph.chat-teardrop.fill.svg */; };
 		E090E66E31FD785DEFF3B2E1 /* ph.smiley-angry.svg in Resources */ = {isa = PBXBuildFile; fileRef = E270712491C7622AACBC1B6C /* ph.smiley-angry.svg */; };
@@ -3019,6 +3055,7 @@
 		E48790EE6E176CCCA79591E4 /* ph.gear-fine.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = FF0768E5EAB86EE90E4FE232 /* ph.gear-fine.fill.svg */; };
 		E492D9DE988CEB4CECBE16E2 /* ph.boxing-glove.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 4250D05A7686C3DBC60C9398 /* ph.boxing-glove.fill.svg */; };
 		E498FD32245F35379AB8D91F /* ph.arrow-square-down-right.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = FE89E3F3D5F3857AFBE9C663 /* ph.arrow-square-down-right.fill.svg */; };
+		E4A51E018FC3F6064054EA14 /* AutomationsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1330D571C459A4F29C72457B /* AutomationsSection.swift */; };
 		E4D502F61BBEACC8CEA73562 /* ph.superset-proper-of.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = E4D07D70A996B8BD755CC1B3 /* ph.superset-proper-of.fill.svg */; };
 		E4F972CE39DECAAFBA3343A5 /* ph.tooth.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 54FEE7E1234C3F66F7B8D397 /* ph.tooth.fill.svg */; };
 		E52FDF576A139DE6BFB4E4EF /* ph.sun.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 9087731B803FF74DC7118E3A /* ph.sun.fill.svg */; };
@@ -3057,6 +3094,7 @@
 		E861C05AACA1B0AD266F5B0A /* ph.cable-car.svg in Resources */ = {isa = PBXBuildFile; fileRef = 44547F75551548C1F98E0100 /* ph.cable-car.svg */; };
 		E8660836BA4CD7A43D6217BD /* ph.robot.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = B6C3A7E144CACD2069E6021F /* ph.robot.fill.svg */; };
 		E885BAFF721AF2C2A691E486 /* ph.cloud-lightning.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 71CBC4FD11A69CBD4A702897 /* ph.cloud-lightning.fill.svg */; };
+		E8867E3A81A3086663157136 /* AutomationDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD708B8E691F4265A280899F /* AutomationDraft.swift */; };
 		E8EA0F07FBCFD946F2849499 /* ph.note-blank.svg in Resources */ = {isa = PBXBuildFile; fileRef = C3E366BCDD888E35F39F64C8 /* ph.note-blank.svg */; };
 		E8EADD3B27997F7A7BC83516 /* ph.presentation.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 64A602D36DA4C7E0462E818E /* ph.presentation.fill.svg */; };
 		E8F51B3F3FE62E546CD28932 /* ph.caret-right.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 409848FB70D17EA4C04D425F /* ph.caret-right.fill.svg */; };
@@ -3190,6 +3228,7 @@
 		F3C6FB1EDB029D3CE8233A99 /* ph.globe-hemisphere-east.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 5D8FC3CC53423132985FAAF6 /* ph.globe-hemisphere-east.fill.svg */; };
 		F3DB3D64C6C637116DE97A0D /* ph.chat-teardrop-dots.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = F3BD34F25D622B2070D4609F /* ph.chat-teardrop-dots.fill.svg */; };
 		F3E3F7B1FE80C086F874D098 /* ph.caret-right.svg in Resources */ = {isa = PBXBuildFile; fileRef = E5379A21D0FAC62A3E6DA757 /* ph.caret-right.svg */; };
+		F3E56AD0984B3DF0B340766A /* AutomationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705C31154543D45848C0DD0F /* AutomationStoreTests.swift */; };
 		F3EC967BA4D48CD8277E7213 /* ph.scan-smiley.svg in Resources */ = {isa = PBXBuildFile; fileRef = 29AD662DD0E07739BFE46582 /* ph.scan-smiley.svg */; };
 		F447010CFF2FD3EC8445ADCF /* ph.dev-to-logo.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = E09F90A9401C7D836F4CC9F2 /* ph.dev-to-logo.fill.svg */; };
 		F44B2C585197CF1667E28818 /* ph.meta-logo.svg in Resources */ = {isa = PBXBuildFile; fileRef = 03E1E65C7E17288ACEE2C3D9 /* ph.meta-logo.svg */; };
@@ -3224,6 +3263,7 @@
 		F6C87DBCCECC374D6558A88D /* ph.laptop.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 295CC58C4933CEF843CDB75C /* ph.laptop.fill.svg */; };
 		F6DF672759CC573CC3D86659 /* ph.circle-half.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 9833F717FEFC90652FA97531 /* ph.circle-half.fill.svg */; };
 		F6E1CB4E74F98A6A40307F4F /* DeviceGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1078ED585A5ECE7DF0A569F6 /* DeviceGroup.swift */; };
+		F6EA76A9CC5FE1B2976F690E /* AutomationModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C16864DFE4B0C913E194839 /* AutomationModelTests.swift */; };
 		F6EF28B9780E05F8B8FCB3A6 /* ph.newspaper-clipping.svg in Resources */ = {isa = PBXBuildFile; fileRef = 7FD49E86A8F92394AD4D093F /* ph.newspaper-clipping.svg */; };
 		F6F465B8122577F4D8C24B33 /* ph.file-pdf.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = D7B71B2D9D5BD57970F290F9 /* ph.file-pdf.fill.svg */; };
 		F7089714B49B8AE9C67344FD /* ph.pen-nib-straight.svg in Resources */ = {isa = PBXBuildFile; fileRef = DF63D021744D3CEBA1646562 /* ph.pen-nib-straight.svg */; };
@@ -3483,6 +3523,7 @@
 		07554CBFF77275451EB54E6B /* ph.scissors.fill.svg */ = {isa = PBXFileReference; path = ph.scissors.fill.svg; sourceTree = "<group>"; };
 		0782A467EB61CA993FEEBFED /* ph.hand-peace.fill.svg */ = {isa = PBXFileReference; path = "ph.hand-peace.fill.svg"; sourceTree = "<group>"; };
 		079EDB4F48ACFE0E1E9027D9 /* ph.football.fill.svg */ = {isa = PBXFileReference; path = ph.football.fill.svg; sourceTree = "<group>"; };
+		07BA194642206C7A138BE4CB /* AutomationBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationBuilderTests.swift; sourceTree = "<group>"; };
 		07C6B5021AD7011C3B5258D4 /* ph.trend-up.fill.svg */ = {isa = PBXFileReference; path = "ph.trend-up.fill.svg"; sourceTree = "<group>"; };
 		07CA0CD4305838B1EBD2BB92 /* ph.download.svg */ = {isa = PBXFileReference; path = ph.download.svg; sourceTree = "<group>"; };
 		07E11AAD587D6EB4B8126024 /* ph.arrow-fat-left.fill.svg */ = {isa = PBXFileReference; path = "ph.arrow-fat-left.fill.svg"; sourceTree = "<group>"; };
@@ -3624,6 +3665,7 @@
 		12F3983C6090A3ABD21B2422 /* ph.equals.fill.svg */ = {isa = PBXFileReference; path = ph.equals.fill.svg; sourceTree = "<group>"; };
 		13008F33B31A00078EF4FF9C /* ph.strategy.fill.svg */ = {isa = PBXFileReference; path = ph.strategy.fill.svg; sourceTree = "<group>"; };
 		1323B4CBD62F6C471EDCDE0C /* ph.yin-yang.fill.svg */ = {isa = PBXFileReference; path = "ph.yin-yang.fill.svg"; sourceTree = "<group>"; };
+		1330D571C459A4F29C72457B /* AutomationsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationsSection.swift; sourceTree = "<group>"; };
 		13497B3E06DADB79DF702B58 /* ph.tree-structure.fill.svg */ = {isa = PBXFileReference; path = "ph.tree-structure.fill.svg"; sourceTree = "<group>"; };
 		1359B98719D1D9D23782463E /* ShortcutButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutButton.swift; sourceTree = "<group>"; };
 		136258CB222245EB1156CB03 /* ph.caret-double-left.fill.svg */ = {isa = PBXFileReference; path = "ph.caret-double-left.fill.svg"; sourceTree = "<group>"; };
@@ -3642,6 +3684,7 @@
 		1444564DC177E7B472C569F8 /* ph.crown.svg */ = {isa = PBXFileReference; path = ph.crown.svg; sourceTree = "<group>"; };
 		144CF80E369EE64107B6D000 /* ph.needle.svg */ = {isa = PBXFileReference; path = ph.needle.svg; sourceTree = "<group>"; };
 		14863A4E325C958C7E8762B7 /* ph.arrow-line-down.svg */ = {isa = PBXFileReference; path = "ph.arrow-line-down.svg"; sourceTree = "<group>"; };
+		14BD2126C3CAD63117C643AF /* VirtualBridgeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualBridgeServiceTests.swift; sourceTree = "<group>"; };
 		14CF95CB4189CDAA4A887BF5 /* ph.book-open.svg */ = {isa = PBXFileReference; path = "ph.book-open.svg"; sourceTree = "<group>"; };
 		150134D9E1B5E29E1804C2A9 /* ph.repeat.fill.svg */ = {isa = PBXFileReference; path = ph.repeat.fill.svg; sourceTree = "<group>"; };
 		15047E259F73273C85869385 /* ph.number-six.svg */ = {isa = PBXFileReference; path = "ph.number-six.svg"; sourceTree = "<group>"; };
@@ -3721,6 +3764,7 @@
 		1B85FFAD649D98D067DC4B5D /* ph.shuffle-simple.svg */ = {isa = PBXFileReference; path = "ph.shuffle-simple.svg"; sourceTree = "<group>"; };
 		1B9E5E2BA34F0A42A585F1A8 /* ph.hand-grabbing.svg */ = {isa = PBXFileReference; path = "ph.hand-grabbing.svg"; sourceTree = "<group>"; };
 		1BA30297151EB3C22453DA35 /* ph.battery-vertical-empty.svg */ = {isa = PBXFileReference; path = "ph.battery-vertical-empty.svg"; sourceTree = "<group>"; };
+		1BC9BB856B1F21EB05CC6737 /* HAPService+CarbonDioxide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HAPService+CarbonDioxide.swift"; sourceTree = "<group>"; };
 		1C3201712040911ED21E0328 /* ph.t-shirt.fill.svg */ = {isa = PBXFileReference; path = "ph.t-shirt.fill.svg"; sourceTree = "<group>"; };
 		1C377D5AFC1EB7B688266719 /* ph.moped-front.svg */ = {isa = PBXFileReference; path = "ph.moped-front.svg"; sourceTree = "<group>"; };
 		1C71B0D0D0EC3325800CEEC8 /* ph.cactus.fill.svg */ = {isa = PBXFileReference; path = ph.cactus.fill.svg; sourceTree = "<group>"; };
@@ -3896,6 +3940,7 @@
 		2A97477BBF379E80EAD5CC26 /* ph.calendar-x.svg */ = {isa = PBXFileReference; path = "ph.calendar-x.svg"; sourceTree = "<group>"; };
 		2AAC48A1C161D5A4AF353701 /* IconPickerPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconPickerPopover.swift; sourceTree = "<group>"; };
 		2AB222F1617457436BDDA03A /* ph.brackets-curly.fill.svg */ = {isa = PBXFileReference; path = "ph.brackets-curly.fill.svg"; sourceTree = "<group>"; };
+		2AECF02EEDE530E5A837268F /* AutomationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationStore.swift; sourceTree = "<group>"; };
 		2B1346A74A30A8993F22A5C0 /* ph.arrow-line-down-right.fill.svg */ = {isa = PBXFileReference; path = "ph.arrow-line-down-right.fill.svg"; sourceTree = "<group>"; };
 		2B142ACDF66279B8A9529588 /* ph.arrow-square-right.fill.svg */ = {isa = PBXFileReference; path = "ph.arrow-square-right.fill.svg"; sourceTree = "<group>"; };
 		2B162FD5393C88336461362C /* ph.password.fill.svg */ = {isa = PBXFileReference; path = ph.password.fill.svg; sourceTree = "<group>"; };
@@ -4073,6 +4118,7 @@
 		3921CE5DC8EE999140919CEB /* ph.cell-signal-full.fill.svg */ = {isa = PBXFileReference; path = "ph.cell-signal-full.fill.svg"; sourceTree = "<group>"; };
 		394168EC13D4A75FEBFDA8EE /* ph.align-left.fill.svg */ = {isa = PBXFileReference; path = "ph.align-left.fill.svg"; sourceTree = "<group>"; };
 		395C92A64DEF53C04F41A9B6 /* ph.map-pin-area.fill.svg */ = {isa = PBXFileReference; path = "ph.map-pin-area.fill.svg"; sourceTree = "<group>"; };
+		3961BC62634C9BBF8E78E1FA /* HAPCarbonDioxideTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAPCarbonDioxideTests.swift; sourceTree = "<group>"; };
 		3977B1EF083C119D9331D8F8 /* HAConnectWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAConnectWindowController.swift; sourceTree = "<group>"; };
 		3978BFF7D0AF5B1B084C3119 /* ph.screwdriver.svg */ = {isa = PBXFileReference; path = ph.screwdriver.svg; sourceTree = "<group>"; };
 		3989464DAE7B1CD2409D3D78 /* ph.floppy-disk-back.svg */ = {isa = PBXFileReference; path = "ph.floppy-disk-back.svg"; sourceTree = "<group>"; };
@@ -4309,6 +4355,7 @@
 		4B39D802C83AA2C19753EFC9 /* ph.password.svg */ = {isa = PBXFileReference; path = ph.password.svg; sourceTree = "<group>"; };
 		4B4005C86EA7BB4B1896FAFE /* ph.sticker.fill.svg */ = {isa = PBXFileReference; path = ph.sticker.fill.svg; sourceTree = "<group>"; };
 		4B874CA0A525F91704FCC1B3 /* BatteryBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryBadge.swift; sourceTree = "<group>"; };
+		4B87FA3FF077C5FAC1C7D0DC /* VirtualDeviceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualDeviceStore.swift; sourceTree = "<group>"; };
 		4BC166A5A6E8292C4A386639 /* ph.rss-simple.fill.svg */ = {isa = PBXFileReference; path = "ph.rss-simple.fill.svg"; sourceTree = "<group>"; };
 		4BE10114AD31F8AD7C1655F7 /* ph.rectangle-dashed.svg */ = {isa = PBXFileReference; path = "ph.rectangle-dashed.svg"; sourceTree = "<group>"; };
 		4BF4DCE4AE91AF603BD938BE /* ph.clock-afternoon.svg */ = {isa = PBXFileReference; path = "ph.clock-afternoon.svg"; sourceTree = "<group>"; };
@@ -4494,6 +4541,7 @@
 		59CE8A38BDBE428F0BF49806 /* ph.airplane.svg */ = {isa = PBXFileReference; path = ph.airplane.svg; sourceTree = "<group>"; };
 		59E6428EF682EB3F22D50C0B /* ph.list-heart.svg */ = {isa = PBXFileReference; path = "ph.list-heart.svg"; sourceTree = "<group>"; };
 		59F073ABF768A0B5F91C3EE1 /* ph.function.svg */ = {isa = PBXFileReference; path = ph.function.svg; sourceTree = "<group>"; };
+		5A031C11122F9992A94EB855 /* VirtualSensorMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualSensorMappingTests.swift; sourceTree = "<group>"; };
 		5A155EC655395F5D5D46FFE4 /* ph.intersect.fill.svg */ = {isa = PBXFileReference; path = ph.intersect.fill.svg; sourceTree = "<group>"; };
 		5A1E5711DE06CDE529FDD21A /* ph.rainbow-cloud.fill.svg */ = {isa = PBXFileReference; path = "ph.rainbow-cloud.fill.svg"; sourceTree = "<group>"; };
 		5A3F87AE974556344CF9D448 /* ph.cake.svg */ = {isa = PBXFileReference; path = ph.cake.svg; sourceTree = "<group>"; };
@@ -4535,6 +4583,7 @@
 		5D90B8591B1E598761AEFBB9 /* ph.file-ini.fill.svg */ = {isa = PBXFileReference; path = "ph.file-ini.fill.svg"; sourceTree = "<group>"; };
 		5DD0D3515F394A33085FD922 /* ph.mouse-left-click.svg */ = {isa = PBXFileReference; path = "ph.mouse-left-click.svg"; sourceTree = "<group>"; };
 		5DD7CAEB26B31B259E864ABB /* ph.eye-slash.svg */ = {isa = PBXFileReference; path = "ph.eye-slash.svg"; sourceTree = "<group>"; };
+		5DE3BCEF7D494D0692CB50AB /* VirtualDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualDevice.swift; sourceTree = "<group>"; };
 		5DE8973580BF220B5B2433ED /* ph.trophy.svg */ = {isa = PBXFileReference; path = ph.trophy.svg; sourceTree = "<group>"; };
 		5E015C0640C2AD9434816885 /* ph.ladder.fill.svg */ = {isa = PBXFileReference; path = ph.ladder.fill.svg; sourceTree = "<group>"; };
 		5E0786F8A1EFDFFDB21D9718 /* ph.file-html.fill.svg */ = {isa = PBXFileReference; path = "ph.file-html.fill.svg"; sourceTree = "<group>"; };
@@ -4631,6 +4680,7 @@
 		63CA54C172C80DBD0EC56201 /* ph.police-car.svg */ = {isa = PBXFileReference; path = "ph.police-car.svg"; sourceTree = "<group>"; };
 		63E57503CCE47F4F0A7CD77F /* ph.upload.svg */ = {isa = PBXFileReference; path = ph.upload.svg; sourceTree = "<group>"; };
 		63F9921E94493157A788CE31 /* ph.check-fat.svg */ = {isa = PBXFileReference; path = "ph.check-fat.svg"; sourceTree = "<group>"; };
+		641ADB10E070C561BD4D95EB /* VirtualControlRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualControlRoutingTests.swift; sourceTree = "<group>"; };
 		641B67C71630B41B1D3274E5 /* ph.lightbulb.svg */ = {isa = PBXFileReference; path = ph.lightbulb.svg; sourceTree = "<group>"; };
 		64257B06013881E578AA5E54 /* ph.sigma.fill.svg */ = {isa = PBXFileReference; path = ph.sigma.fill.svg; sourceTree = "<group>"; };
 		64271C88A3D23516F99FD89D /* ph.mask-sad.svg */ = {isa = PBXFileReference; path = "ph.mask-sad.svg"; sourceTree = "<group>"; };
@@ -4746,7 +4796,9 @@
 		6BDB09B5997632AB2BBEDB48 /* ph.warning-circle.svg */ = {isa = PBXFileReference; path = "ph.warning-circle.svg"; sourceTree = "<group>"; };
 		6BE581FABE3E8AE46CC0A1A1 /* ph.tip-jar.svg */ = {isa = PBXFileReference; path = "ph.tip-jar.svg"; sourceTree = "<group>"; };
 		6C00672F25700531A8B8D86D /* ph.upload-simple.svg */ = {isa = PBXFileReference; path = "ph.upload-simple.svg"; sourceTree = "<group>"; };
+		6C16864DFE4B0C913E194839 /* AutomationModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationModelTests.swift; sourceTree = "<group>"; };
 		6C288B9AB28344EE87EC78DC /* ph.face-mask.svg */ = {isa = PBXFileReference; path = "ph.face-mask.svg"; sourceTree = "<group>"; };
+		6C324A49E5DE7383B3116A5A /* VirtualControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualControl.swift; sourceTree = "<group>"; };
 		6C60180BF184A0F1268D9C6C /* ph.golf.svg */ = {isa = PBXFileReference; path = ph.golf.svg; sourceTree = "<group>"; };
 		6C73F0039084006E58F11C5B /* ph.arrow-down.fill.svg */ = {isa = PBXFileReference; path = "ph.arrow-down.fill.svg"; sourceTree = "<group>"; };
 		6C87BAF10012B46DD3CE8B36 /* ph.app-window.fill.svg */ = {isa = PBXFileReference; path = "ph.app-window.fill.svg"; sourceTree = "<group>"; };
@@ -4806,6 +4858,7 @@
 		70056C596CC06C370C528E5F /* HACameraSignaling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HACameraSignaling.swift; sourceTree = "<group>"; };
 		7034F7070D18D894F3FFD003 /* ph.bridge.fill.svg */ = {isa = PBXFileReference; path = ph.bridge.fill.svg; sourceTree = "<group>"; };
 		704D6DC4B595E3B966DB4274 /* ph.share-network.fill.svg */ = {isa = PBXFileReference; path = "ph.share-network.fill.svg"; sourceTree = "<group>"; };
+		705C31154543D45848C0DD0F /* AutomationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationStoreTests.swift; sourceTree = "<group>"; };
 		708E00FD307D9F4BF5F0047B /* ph.youtube-logo.fill.svg */ = {isa = PBXFileReference; path = "ph.youtube-logo.fill.svg"; sourceTree = "<group>"; };
 		7092D0C92D0FD903C128DBDA /* GroupMenuItem+Controls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GroupMenuItem+Controls.swift"; sourceTree = "<group>"; };
 		7092E4C96DF4B6DEE61A6224 /* ph.rectangle.fill.svg */ = {isa = PBXFileReference; path = ph.rectangle.fill.svg; sourceTree = "<group>"; };
@@ -5109,6 +5162,7 @@
 		87AA27C6B01DF99F05BE4C39 /* ph.map-pin-simple.fill.svg */ = {isa = PBXFileReference; path = "ph.map-pin-simple.fill.svg"; sourceTree = "<group>"; };
 		87B57BDFA027187F88EC0EA3 /* ph.user-switch.fill.svg */ = {isa = PBXFileReference; path = "ph.user-switch.fill.svg"; sourceTree = "<group>"; };
 		87C0657576D342F31EB24BDA /* ph.arrow-circle-down.svg */ = {isa = PBXFileReference; path = "ph.arrow-circle-down.svg"; sourceTree = "<group>"; };
+		87E14E1F8CBB9739D49528D6 /* HomeKitBridgeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeKitBridgeSection.swift; sourceTree = "<group>"; };
 		87F21C913A301D78BB17A55C /* ph.flag-banner.svg */ = {isa = PBXFileReference; path = "ph.flag-banner.svg"; sourceTree = "<group>"; };
 		88035A5CCA3AECF8FAD38C7E /* ph.arrow-u-left-up.fill.svg */ = {isa = PBXFileReference; path = "ph.arrow-u-left-up.fill.svg"; sourceTree = "<group>"; };
 		8804611FD7F5C5449C7B6C56 /* ph.folder-dashed.svg */ = {isa = PBXFileReference; path = "ph.folder-dashed.svg"; sourceTree = "<group>"; };
@@ -5194,6 +5248,7 @@
 		8E67C906ECD67B8E10255EFC /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		8E754665B8BE0F2D5FA7B51A /* ph.phone-list.svg */ = {isa = PBXFileReference; path = "ph.phone-list.svg"; sourceTree = "<group>"; };
 		8E898364C3C60080171FCC62 /* ph.hoodie.svg */ = {isa = PBXFileReference; path = ph.hoodie.svg; sourceTree = "<group>"; };
+		8E912B10122DBDD307334052 /* VirtualBridgeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualBridgeService.swift; sourceTree = "<group>"; };
 		8EB5C2198F11331F049CB188 /* ph.number-square-two.svg */ = {isa = PBXFileReference; path = "ph.number-square-two.svg"; sourceTree = "<group>"; };
 		8EB6BCA1CF92DEF5FAAE075A /* ph.rows.svg */ = {isa = PBXFileReference; path = ph.rows.svg; sourceTree = "<group>"; };
 		8ECC6F23FD69507C030DF849 /* ph.swatches.fill.svg */ = {isa = PBXFileReference; path = ph.swatches.fill.svg; sourceTree = "<group>"; };
@@ -5314,6 +5369,7 @@
 		98341E0EC24B0FF462ABB32F /* ph.high-definition.svg */ = {isa = PBXFileReference; path = "ph.high-definition.svg"; sourceTree = "<group>"; };
 		983628CC2607103428C1E510 /* ph.graphics-card.svg */ = {isa = PBXFileReference; path = "ph.graphics-card.svg"; sourceTree = "<group>"; };
 		983861BA8371302B0F9BD482 /* ph.chart-donut.svg */ = {isa = PBXFileReference; path = "ph.chart-donut.svg"; sourceTree = "<group>"; };
+		985376E03F8018247B75B845 /* VirtualDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualDeviceTests.swift; sourceTree = "<group>"; };
 		98653A8EA5691F71C702F1AB /* ph.tote-simple.svg */ = {isa = PBXFileReference; path = "ph.tote-simple.svg"; sourceTree = "<group>"; };
 		9870C3880131AB38C0A11C6A /* ph.gift.fill.svg */ = {isa = PBXFileReference; path = ph.gift.fill.svg; sourceTree = "<group>"; };
 		988AA6031745D5B34D157500 /* ph.slack-logo.fill.svg */ = {isa = PBXFileReference; path = "ph.slack-logo.fill.svg"; sourceTree = "<group>"; };
@@ -5422,6 +5478,7 @@
 		A190EAC015B54A70C2A0DF4D /* ph.speaker-simple-slash.svg */ = {isa = PBXFileReference; path = "ph.speaker-simple-slash.svg"; sourceTree = "<group>"; };
 		A1A6DC89273739E13141078A /* ph.soundcloud-logo.svg */ = {isa = PBXFileReference; path = "ph.soundcloud-logo.svg"; sourceTree = "<group>"; };
 		A1A89D22049DEDEB9DB41D0C /* ph.heart-half.svg */ = {isa = PBXFileReference; path = "ph.heart-half.svg"; sourceTree = "<group>"; };
+		A1B90430D58295703FB84ED9 /* AutomationEngineCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationEngineCoreTests.swift; sourceTree = "<group>"; };
 		A1BF44C4596F2B41B165C6B5 /* ph.cloud-rain.fill.svg */ = {isa = PBXFileReference; path = "ph.cloud-rain.fill.svg"; sourceTree = "<group>"; };
 		A22EB7E47D5B9B0FA0052231 /* ph.detective.fill.svg */ = {isa = PBXFileReference; path = ph.detective.fill.svg; sourceTree = "<group>"; };
 		A22FAEC693B2B174D9A47AC8 /* ph.list-star.svg */ = {isa = PBXFileReference; path = "ph.list-star.svg"; sourceTree = "<group>"; };
@@ -5489,6 +5546,7 @@
 		A690DAB6F4DA26F9D65605B1 /* ph.door.svg */ = {isa = PBXFileReference; path = ph.door.svg; sourceTree = "<group>"; };
 		A6AA73595CEBA3B3C17C3E0F /* ph.pix-logo.fill.svg */ = {isa = PBXFileReference; path = "ph.pix-logo.fill.svg"; sourceTree = "<group>"; };
 		A6AD7C61A81888DEF43F63BF /* ph.magnet.fill.svg */ = {isa = PBXFileReference; path = ph.magnet.fill.svg; sourceTree = "<group>"; };
+		A6C3F561C859455DA9F85580 /* PreferencesManager+VirtualBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PreferencesManager+VirtualBridge.swift"; sourceTree = "<group>"; };
 		A6CC9935F5975FA57A1090BA /* HomeKitManager+Motion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeKitManager+Motion.swift"; sourceTree = "<group>"; };
 		A6E8F4464B0E2B6A092288CA /* ph.truck-trailer.fill.svg */ = {isa = PBXFileReference; path = "ph.truck-trailer.fill.svg"; sourceTree = "<group>"; };
 		A6EFF87080B9FE0B62F67D9B /* ph.link-simple-break.fill.svg */ = {isa = PBXFileReference; path = "ph.link-simple-break.fill.svg"; sourceTree = "<group>"; };
@@ -5921,12 +5979,14 @@
 		C71FCD432D1ADAC7A7864688 /* ph.infinity.fill.svg */ = {isa = PBXFileReference; path = ph.infinity.fill.svg; sourceTree = "<group>"; };
 		C72CE54CCD1B244C0E45736F /* ph.heartbeat.svg */ = {isa = PBXFileReference; path = ph.heartbeat.svg; sourceTree = "<group>"; };
 		C7351BAA2BC4FB4EB00FB8E8 /* ph.envelope-open.fill.svg */ = {isa = PBXFileReference; path = "ph.envelope-open.fill.svg"; sourceTree = "<group>"; };
+		C74106EAB1CEB975E6B3DFCC /* FilePairingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePairingStore.swift; sourceTree = "<group>"; };
 		C752EA2993C0BABD00864487 /* ph.shield-slash.fill.svg */ = {isa = PBXFileReference; path = "ph.shield-slash.fill.svg"; sourceTree = "<group>"; };
 		C75C27EE8AF032B946151881 /* ph.link-simple-horizontal-break.svg */ = {isa = PBXFileReference; path = "ph.link-simple-horizontal-break.svg"; sourceTree = "<group>"; };
 		C7748DEA49BDEFEBFBD35C42 /* ph.command.svg */ = {isa = PBXFileReference; path = ph.command.svg; sourceTree = "<group>"; };
 		C7868095E08D59192601DF02 /* ph.file-dashed.fill.svg */ = {isa = PBXFileReference; path = "ph.file-dashed.fill.svg"; sourceTree = "<group>"; };
 		C79BB78A623EE8949384AA3A /* ph.number-seven.fill.svg */ = {isa = PBXFileReference; path = "ph.number-seven.fill.svg"; sourceTree = "<group>"; };
 		C7A0784CFACB6CF42DE5111E /* ph.envelope.fill.svg */ = {isa = PBXFileReference; path = ph.envelope.fill.svg; sourceTree = "<group>"; };
+		C803C5C3BD7362C8437F7658 /* AutomationEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationEngine.swift; sourceTree = "<group>"; };
 		C821311BF55EFDF828E96E36 /* ph.person-simple-circle.svg */ = {isa = PBXFileReference; path = "ph.person-simple-circle.svg"; sourceTree = "<group>"; };
 		C841DE38D751CC7B84F83D44 /* ph.greater-than.fill.svg */ = {isa = PBXFileReference; path = "ph.greater-than.fill.svg"; sourceTree = "<group>"; };
 		C860BB9FC272871C08C27850 /* ph.git-commit.svg */ = {isa = PBXFileReference; path = "ph.git-commit.svg"; sourceTree = "<group>"; };
@@ -5997,6 +6057,7 @@
 		CCBA56EA2DE7F566F521E437 /* ph.amazon-logo.svg */ = {isa = PBXFileReference; path = "ph.amazon-logo.svg"; sourceTree = "<group>"; };
 		CCBCF8E5EB2FE6A09263F4D4 /* ph.music-note-simple.svg */ = {isa = PBXFileReference; path = "ph.music-note-simple.svg"; sourceTree = "<group>"; };
 		CD24A5D74510339871B044AA /* ph.bookmark-simple.fill.svg */ = {isa = PBXFileReference; path = "ph.bookmark-simple.fill.svg"; sourceTree = "<group>"; };
+		CD6573418A912EA33D229B9F /* VirtualDeviceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualDeviceStoreTests.swift; sourceTree = "<group>"; };
 		CD66A8A4D64B8D2CAC8A5D3A /* ph.minus-circle.fill.svg */ = {isa = PBXFileReference; path = "ph.minus-circle.fill.svg"; sourceTree = "<group>"; };
 		CD66D1BD302F215CBBA77F41 /* ph.panorama.fill.svg */ = {isa = PBXFileReference; path = ph.panorama.fill.svg; sourceTree = "<group>"; };
 		CD70E3C1B0B2D3FBB47D9112 /* ph.arrow-arc-right.svg */ = {isa = PBXFileReference; path = "ph.arrow-arc-right.svg"; sourceTree = "<group>"; };
@@ -6036,6 +6097,7 @@
 		D03EC1AE301AB92944DF672A /* ph.rainbow.fill.svg */ = {isa = PBXFileReference; path = ph.rainbow.fill.svg; sourceTree = "<group>"; };
 		D059B279D4607D57AC0E41D4 /* ph.tree.svg */ = {isa = PBXFileReference; path = ph.tree.svg; sourceTree = "<group>"; };
 		D059BD954847C83814172714 /* HACoverMenuItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HACoverMenuItemTests.swift; sourceTree = "<group>"; };
+		D06560FD288CA69608EE122E /* AutomationEngineRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationEngineRuntimeTests.swift; sourceTree = "<group>"; };
 		D06B1558A45F42060158105E /* ph.columns-plus-left.svg */ = {isa = PBXFileReference; path = "ph.columns-plus-left.svg"; sourceTree = "<group>"; };
 		D0AB72DCDAA64885B7295217 /* ph.align-center-horizontal.fill.svg */ = {isa = PBXFileReference; path = "ph.align-center-horizontal.fill.svg"; sourceTree = "<group>"; };
 		D0B09499A4D3EEF659936E0C /* ph.text-t.svg */ = {isa = PBXFileReference; path = "ph.text-t.svg"; sourceTree = "<group>"; };
@@ -6447,6 +6509,7 @@
 		F111C637BEEEED809EDF0099 /* ph.sneaker-move.svg */ = {isa = PBXFileReference; path = "ph.sneaker-move.svg"; sourceTree = "<group>"; };
 		F122568A85A12D04E8EA23C0 /* ph.couch.svg */ = {isa = PBXFileReference; path = ph.couch.svg; sourceTree = "<group>"; };
 		F13014358C6E3C5C35B84220 /* ph.funnel-x.fill.svg */ = {isa = PBXFileReference; path = "ph.funnel-x.fill.svg"; sourceTree = "<group>"; };
+		F1336E9251DBA9D947B18CD0 /* Automation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Automation.swift; sourceTree = "<group>"; };
 		F1382E779CF427EFB40BEB65 /* ph.folders.svg */ = {isa = PBXFileReference; path = ph.folders.svg; sourceTree = "<group>"; };
 		F1B915B950E794744AE705F6 /* ph.chart-scatter.fill.svg */ = {isa = PBXFileReference; path = "ph.chart-scatter.fill.svg"; sourceTree = "<group>"; };
 		F1BEE658C86A8032E1FAFCE2 /* ph.arrow-bend-left-up.fill.svg */ = {isa = PBXFileReference; path = "ph.arrow-bend-left-up.fill.svg"; sourceTree = "<group>"; };
@@ -6578,6 +6641,7 @@
 		FD16BBF84484FD6F857C241D /* ph.clover.svg */ = {isa = PBXFileReference; path = ph.clover.svg; sourceTree = "<group>"; };
 		FD3D1A58A1D478EEE66BACBD /* ph.file-js.fill.svg */ = {isa = PBXFileReference; path = "ph.file-js.fill.svg"; sourceTree = "<group>"; };
 		FD58426569ABF984E9F04441 /* ph.text-outdent.fill.svg */ = {isa = PBXFileReference; path = "ph.text-outdent.fill.svg"; sourceTree = "<group>"; };
+		FD708B8E691F4265A280899F /* AutomationDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationDraft.swift; sourceTree = "<group>"; };
 		FD735AE6D9B05F2D17E0B83F /* ph.gift.svg */ = {isa = PBXFileReference; path = ph.gift.svg; sourceTree = "<group>"; };
 		FD822D10C3A13098C7D0A748 /* ph.radio-button.svg */ = {isa = PBXFileReference; path = "ph.radio-button.svg"; sourceTree = "<group>"; };
 		FD823181DF704BA470768E13 /* ph.dice-four.fill.svg */ = {isa = PBXFileReference; path = "ph.dice-four.fill.svg"; sourceTree = "<group>"; };
@@ -6642,6 +6706,18 @@
 			files = (
 				D2AAE6C09917F8A2C000CDA7 /* CoreWLAN.framework in Frameworks */,
 				577D81D9B7F847D199BC05CF /* CoreLocation.framework in Frameworks */,
+				07E6AF5C498445C5FCD2E9F7 /* HAPSwift in Frameworks */,
+				6898FFF6A558555F887E9763 /* HAPApple in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B3E3269437BDA4617A1BCE71 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B241F2942A1E9EAC5AE5E314 /* HAPSwift in Frameworks */,
+				128A80B51C47332F17216C5D /* HAPApple in Frameworks */,
+				19715D949570E81028E1D58C /* HAPCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6699,8 +6775,10 @@
 				A3A3EB6D0DE7E9C0DE57ABAF /* Protocols.swift */,
 				46EB6A2D48574EFA0940AA54 /* ValueConversion.swift */,
 				3A45056D1FCE4E16C96D619A /* ActionEngine */,
+				C034EE6C32AEDC220078D14F /* Automations */,
 				6D6AC7C83D2E3676E42DF659 /* Controls */,
 				D2258862CCE787F231C5D76E /* DesignSystem */,
+				6449651D52E31398DDF8D76B /* HAPBridge */,
 				31F297AB346E189FF215E374 /* HomeAssistant */,
 				F993AEE95F23CC68310DE85E /* MenuItems */,
 				244BE2D237242FEC7E6B15A5 /* Models */,
@@ -6742,12 +6820,14 @@
 			children = (
 				BB02A6E6A0F93A3A51FBACC1 /* AboutSection.swift */,
 				2D3F7957F56A79CE0D4AA33A /* AdvancedSection.swift */,
+				1330D571C459A4F29C72457B /* AutomationsSection.swift */,
 				0120D24898978AAE26F2A54D /* CamerasSection.swift */,
 				0F9EE2F37DB271A185EC2CF7 /* CamerasSection+TableDelegate.swift */,
 				2015876131A8AE52D26618FC /* DeeplinksSection.swift */,
 				62AD62C3749331FE2DA3CA6B /* GeneralSection.swift */,
 				45ADAE5712E4621056FF217C /* GroupEditorPanel.swift */,
 				FE7B43E8AAC9847448C2E493 /* HomeAssistantSection.swift */,
+				87E14E1F8CBB9739D49528D6 /* HomeKitBridgeSection.swift */,
 				1FAAD4F9DABD4B0034824C91 /* ItsyhomeIOSSection.swift */,
 				3FE4F034B6941A4D32654933 /* ItsytvSection.swift */,
 				A793D4567D7D01049F5AAECA /* NetworksSection.swift */,
@@ -6837,6 +6917,19 @@
 			);
 			name = iOS;
 			path = Itsyhome/iOS;
+			sourceTree = "<group>";
+		};
+		6449651D52E31398DDF8D76B /* HAPBridge */ = {
+			isa = PBXGroup;
+			children = (
+				C74106EAB1CEB975E6B3DFCC /* FilePairingStore.swift */,
+				1BC9BB856B1F21EB05CC6737 /* HAPService+CarbonDioxide.swift */,
+				8E912B10122DBDD307334052 /* VirtualBridgeService.swift */,
+				6C324A49E5DE7383B3116A5A /* VirtualControl.swift */,
+				5DE3BCEF7D494D0692CB50AB /* VirtualDevice.swift */,
+				4B87FA3FF077C5FAC1C7D0DC /* VirtualDeviceStore.swift */,
+			);
+			path = HAPBridge;
 			sourceTree = "<group>";
 		};
 		6D6AC7C83D2E3676E42DF659 /* Controls */ = {
@@ -9944,6 +10037,7 @@
 				9F015059030FE61A6C4B4AE5 /* PreferencesManager+Ordering.swift */,
 				113E78ECB1A5FF5BCF3830FF /* PreferencesManager+Pinned.swift */,
 				31BD1E0F7E27ABA8E0379495 /* PreferencesManager+Shortcuts.swift */,
+				A6C3F561C859455DA9F85580 /* PreferencesManager+VirtualBridge.swift */,
 				DDB13572FA0DD4098A9721D2 /* SettingsCard.swift */,
 				A7EC2BE57F565949161AF7B5 /* SettingsSectionContainer.swift */,
 				8E67C906ECD67B8E10255EFC /* SettingsView.swift */,
@@ -9968,6 +10062,11 @@
 			children = (
 				D4645448B313F9D7E3EDB0D5 /* ACMenuItemTests.swift */,
 				28C329B5FD2B0194CBC879C3 /* AirPurifierMenuItemTests.swift */,
+				07BA194642206C7A138BE4CB /* AutomationBuilderTests.swift */,
+				A1B90430D58295703FB84ED9 /* AutomationEngineCoreTests.swift */,
+				D06560FD288CA69608EE122E /* AutomationEngineRuntimeTests.swift */,
+				6C16864DFE4B0C913E194839 /* AutomationModelTests.swift */,
+				705C31154543D45848C0DD0F /* AutomationStoreTests.swift */,
 				53DE4E58DDFA9873C92D45D4 /* BlindMenuItemTests.swift */,
 				B9EBA01EDDE859ED8AC024C5 /* CloudSyncManagerTests.swift */,
 				78063132727D342A2B432E1C /* CloudSyncTranslatorCameraTests.swift */,
@@ -9981,6 +10080,7 @@
 				541FE38BCF61C281DD5C2C83 /* FanMenuItemTests.swift */,
 				71887325832D4E805F89008F /* GarageDoorMenuItemTests.swift */,
 				D059BD954847C83814172714 /* HACoverMenuItemTests.swift */,
+				3961BC62634C9BBF8E78E1FA /* HAPCarbonDioxideTests.swift */,
 				180BEA38542C4E634A93B690 /* HumidifierMenuItemTests.swift */,
 				64DD4EA4CF7186C846E795AD /* IconOverrideTests.swift */,
 				1013245D5960DD38DB94DEE0 /* IconResolverTests.swift */,
@@ -9998,6 +10098,11 @@
 				A4588D4410C203F9FB823FC5 /* ThermostatMenuItemTests.swift */,
 				4C1BB4554FA59FCE166E2B86 /* ValueConversionTests.swift */,
 				16C85B3C4A8FDF2ACD4001F3 /* ValveMenuItemTests.swift */,
+				14BD2126C3CAD63117C643AF /* VirtualBridgeServiceTests.swift */,
+				641ADB10E070C561BD4D95EB /* VirtualControlRoutingTests.swift */,
+				CD6573418A912EA33D229B9F /* VirtualDeviceStoreTests.swift */,
+				985376E03F8018247B75B845 /* VirtualDeviceTests.swift */,
+				5A031C11122F9992A94EB855 /* VirtualSensorMappingTests.swift */,
 				330AF536EF7751BA30251B61 /* WebRTCSDPReorderTests.swift */,
 				6DF301553EF8494AC4153659 /* ActionEngineTests */,
 				F53F5135A13ABCB88BBAB32F /* HomeAssistant */,
@@ -10013,6 +10118,17 @@
 			);
 			name = Resources;
 			path = Itsyhome/Resources;
+			sourceTree = "<group>";
+		};
+		C034EE6C32AEDC220078D14F /* Automations */ = {
+			isa = PBXGroup;
+			children = (
+				F1336E9251DBA9D947B18CD0 /* Automation.swift */,
+				FD708B8E691F4265A280899F /* AutomationDraft.swift */,
+				C803C5C3BD7362C8437F7658 /* AutomationEngine.swift */,
+				2AECF02EEDE530E5A837268F /* AutomationStore.swift */,
+			);
+			path = Automations;
 			sourceTree = "<group>";
 		};
 		D2258862CCE787F231C5D76E /* DesignSystem */ = {
@@ -10132,6 +10248,7 @@
 			buildPhases = (
 				DD8CD3634C51BFE29E20799E /* Sources */,
 				612466FC9E8DD93371A37307 /* Resources */,
+				B3E3269437BDA4617A1BCE71 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -10140,6 +10257,9 @@
 			);
 			name = macOSBridgeTests;
 			packageProductDependencies = (
+				A726444284976417DEF72286 /* HAPSwift */,
+				07C3EEE5DFEF1156CC03B2FE /* HAPApple */,
+				FC3CEBE6982A4F9F31F8E6E0 /* HAPCore */,
 			);
 			productName = macOSBridgeTests;
 			productReference = AFFF50FE92C7137DE82A4A69 /* macOSBridgeTests.xctest */;
@@ -10180,6 +10300,8 @@
 			);
 			name = macOSBridge;
 			packageProductDependencies = (
+				2083564DCF5AF576E19BCAD6 /* HAPSwift */,
+				580B079BA4E63260A1B785F1 /* HAPApple */,
 			);
 			productName = macOSBridge;
 			productReference = 5735B31C003BD03DE4B28206 /* macOSBridge.bundle */;
@@ -10209,7 +10331,6 @@
 				};
 			};
 			buildConfigurationList = 8489DF86026CFE345AE26F24 /* Build configuration list for PBXProject "Itsyhome" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -10231,8 +10352,10 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				4B83A3AD3D02B152E08700AF /* XCRemoteSwiftPackageReference "webrtc-xcframework" */,
+				5352D9EE68FFE70DDEAAEA68 /* XCRemoteSwiftPackageReference "hap-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
+			productRefGroup = 2AAE444238D06D49873AE95B /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -13378,6 +13501,11 @@
 				2780E8A3CC3916038B2D93EF /* ActionParser.swift in Sources */,
 				58F2E76BE45DD0ACB598D99A /* AdvancedSection.swift in Sources */,
 				772EAC65582AA05AFFA09210 /* AirPurifierMenuItem.swift in Sources */,
+				263B73AD98F09C7A5682555F /* Automation.swift in Sources */,
+				06563D2DCDD0D3B3AB999B7E /* AutomationDraft.swift in Sources */,
+				0D139D423FB3B430F5206105 /* AutomationEngine.swift in Sources */,
+				63C90468615234BDAF63C8C0 /* AutomationStore.swift in Sources */,
+				E4A51E018FC3F6064054EA14 /* AutomationsSection.swift in Sources */,
 				3B59DD36C2400864DCEE2CA3 /* BaseMenuItems.swift in Sources */,
 				FD32F8E90693ED82AD1DC974 /* BatteryBadge.swift in Sources */,
 				CA8E1F973147B8CE2E58FA52 /* BlindMenuItem.swift in Sources */,
@@ -13399,6 +13527,7 @@
 				7BB119B671B3D114D30396B0 /* DeviceResolver.swift in Sources */,
 				2C00E46186081351EA102328 /* EntityMapper.swift in Sources */,
 				80BA4CBB1ADDA67E5A9ABB5A /* FanMenuItem.swift in Sources */,
+				BBD098B4DA5343FA9785BB5A /* FilePairingStore.swift in Sources */,
 				F16D8A6F08317DD456A24D2E /* FlowLayoutView.swift in Sources */,
 				259E77A4CA92FB96D11ECD4C /* GarageDoorMenuItem.swift in Sources */,
 				13CAC53E00A58CDF49407098 /* GeneralSection.swift in Sources */,
@@ -13415,6 +13544,7 @@
 				C75447EACE1D4BE50218DB35 /* HAHumidifierMenuItem.swift in Sources */,
 				6A08A1E13F3F2DEB3D28188C /* HALockMenuItem.swift in Sources */,
 				D3C658BC3BB56C1E309511C1 /* HAModels.swift in Sources */,
+				A997078001F9A7A84D60684A /* HAPService+CarbonDioxide.swift in Sources */,
 				E36468EF65BF34164C05B424 /* HASecuritySystemMenuItem.swift in Sources */,
 				DCA1F3C588948A0CA6DF932D /* HASuccessWindowController.swift in Sources */,
 				9117D00CD3A0C24D4B12E783 /* HAURLValidator.swift in Sources */,
@@ -13427,6 +13557,7 @@
 				233C62567908A3824EB0BE64 /* HomeAssistantPlatform+Delegate.swift in Sources */,
 				AD8E2EAD19CFB11A3B7AF6A7 /* HomeAssistantPlatform.swift in Sources */,
 				2F3C6FD4C3B045F4C0A55751 /* HomeAssistantSection.swift in Sources */,
+				A363229EA501E1013F3E7665 /* HomeKitBridgeSection.swift in Sources */,
 				FF0012DB814406E8B62C17A7 /* HomeKitStates.swift in Sources */,
 				B6E0BA859343F2AC750C12D5 /* HotkeyManager.swift in Sources */,
 				2FA906D09DF2D10CD127C5EB /* HumidifierMenuItem.swift in Sources */,
@@ -13462,6 +13593,7 @@
 				BD8CC083B6C960CE92172856 /* PreferencesManager+Ordering.swift in Sources */,
 				107190609220A54BD547652D /* PreferencesManager+Pinned.swift in Sources */,
 				B1D9FD4BADEA28A3253BFB45 /* PreferencesManager+Shortcuts.swift in Sources */,
+				203F0C55192C081CCCC3DC07 /* PreferencesManager+VirtualBridge.swift in Sources */,
 				D2096D71A418CA85F0ECD074 /* PreferencesManager.swift in Sources */,
 				20065FF911389BDD959B2D6B /* ProManager.swift in Sources */,
 				3468ABB31915D39AF41D2621 /* ProProducts.swift in Sources */,
@@ -13487,6 +13619,10 @@
 				1F40AE6DB3424BCC0EC82C42 /* URLSchemeHandler.swift in Sources */,
 				93F37AF55F715D6075134E69 /* ValueConversion.swift in Sources */,
 				CCFB8C68628CB06195CD5CBB /* ValveMenuItem.swift in Sources */,
+				5AA09932E737992329CBD3A0 /* VirtualBridgeService.swift in Sources */,
+				4AA96EA09DFF724A521D31EF /* VirtualControl.swift in Sources */,
+				B6992A1E3C19774531C6BCEA /* VirtualDevice.swift in Sources */,
+				B884D90C7F075400509E75CA /* VirtualDeviceStore.swift in Sources */,
 				420204561B254570779E1564 /* WebRTCSDPReorder.swift in Sources */,
 				0C57D09568CED9F45FD2EBE7 /* WebhookResponses.swift in Sources */,
 				5356F633677BBC4303ACA417 /* WebhookServer+Endpoints.swift in Sources */,
@@ -13508,6 +13644,15 @@
 				CECFFBB02999B556D5D55093 /* ActionParserTests.swift in Sources */,
 				5E2CF28F91004D72D8819802 /* AirPurifierMenuItem.swift in Sources */,
 				B8EE23FE23CA886CD1FC81A5 /* AirPurifierMenuItemTests.swift in Sources */,
+				E051DA42EAC20884A09CC995 /* Automation.swift in Sources */,
+				1F34F501B6E0291D3BAD2404 /* AutomationBuilderTests.swift in Sources */,
+				E8867E3A81A3086663157136 /* AutomationDraft.swift in Sources */,
+				3A55CDF7EDEEEB416A4361E1 /* AutomationEngine.swift in Sources */,
+				3416A0842E7E4AF0082FB1CD /* AutomationEngineCoreTests.swift in Sources */,
+				C14BD02B97B773817D81A387 /* AutomationEngineRuntimeTests.swift in Sources */,
+				F6EA76A9CC5FE1B2976F690E /* AutomationModelTests.swift in Sources */,
+				A08322396E64BD00FF43B146 /* AutomationStore.swift in Sources */,
+				F3E56AD0984B3DF0B340766A /* AutomationStoreTests.swift in Sources */,
 				16A327E2FD58F4B48606729C /* BaseMenuItems.swift in Sources */,
 				9113B753AD9A4943DDC66A09 /* BatteryBadge.swift in Sources */,
 				851260AF14FDF357AD88C04F /* BlindMenuItem.swift in Sources */,
@@ -13537,6 +13682,7 @@
 				8C0D027EEB4E3922916B142E /* EntityMapperTests.swift in Sources */,
 				73574BD61159AC8923B414F8 /* FanMenuItem.swift in Sources */,
 				4E696B26D7F1842CB2AEA9B6 /* FanMenuItemTests.swift in Sources */,
+				6F14900723B76DA77378AB94 /* FilePairingStore.swift in Sources */,
 				B587311D735AA9ED42CD2AFC /* FlowLayoutView.swift in Sources */,
 				530B7958DAC64B1723E66A79 /* GarageDoorMenuItem.swift in Sources */,
 				13736DAF6F660C482265B9FA /* GarageDoorMenuItemTests.swift in Sources */,
@@ -13554,6 +13700,8 @@
 				A7F39222155735925EC83103 /* HALockMenuItem.swift in Sources */,
 				8FFE17F91B99FCB47BCB29D0 /* HAModels.swift in Sources */,
 				DF2EA2565247431E445B32EE /* HAModelsTests.swift in Sources */,
+				134E7F2B048EE730C61E1506 /* HAPCarbonDioxideTests.swift in Sources */,
+				5860C2828B56E3A5CB0E557B /* HAPService+CarbonDioxide.swift in Sources */,
 				BAD9A04129591C3A9C0E47AB /* HASecuritySystemMenuItem.swift in Sources */,
 				AD4D681D6C6471E0B10CB188 /* HASuccessWindowController.swift in Sources */,
 				9786E847561D50EAA9FA857F /* HAURLValidator.swift in Sources */,
@@ -13599,6 +13747,7 @@
 				1F3F167553112C17651DF3BA /* PreferencesManager+Ordering.swift in Sources */,
 				87037F0B503C4EA9855C096B /* PreferencesManager+Pinned.swift in Sources */,
 				6BE2CFCD7BA7383199064680 /* PreferencesManager+Shortcuts.swift in Sources */,
+				452A97B863515090E5E8F020 /* PreferencesManager+VirtualBridge.swift in Sources */,
 				158EC3D55E6D386D2AD13DC0 /* PreferencesManager.swift in Sources */,
 				81700D54D56303C83DD65445 /* PreferencesManagerTests.swift in Sources */,
 				64A2F6EC52618A2CA486EA00 /* ProManager.swift in Sources */,
@@ -13630,6 +13779,15 @@
 				069D686EF497B4BE291ED8F9 /* ValueConversionTests.swift in Sources */,
 				1539311789FA41246C3F438C /* ValveMenuItem.swift in Sources */,
 				21E1F6CE76E069D99FB6F811 /* ValveMenuItemTests.swift in Sources */,
+				7B9EF3BF43FFC8C0B65965D6 /* VirtualBridgeService.swift in Sources */,
+				AD9577C4B5B972D6138BED64 /* VirtualBridgeServiceTests.swift in Sources */,
+				08E942B7ABD7F481779D182C /* VirtualControl.swift in Sources */,
+				4AF93F5BC79FFC414056F3EA /* VirtualControlRoutingTests.swift in Sources */,
+				B249DC3DA0DB85D2E667C678 /* VirtualDevice.swift in Sources */,
+				8C2A7EC591961E7D7BE93FBD /* VirtualDeviceStore.swift in Sources */,
+				4A4DF6C23BEC47364E74F9BC /* VirtualDeviceStoreTests.swift in Sources */,
+				B324755A68272ADECD3E2882 /* VirtualDeviceTests.swift in Sources */,
+				2B6F71872A7D7828B70D079D /* VirtualSensorMappingTests.swift in Sources */,
 				4E7FFBCBCDF5E8FBAE6B1C6B /* WebRTCSDPReorder.swift in Sources */,
 				A61587328C1C364AA3F260DE /* WebRTCSDPReorderTests.swift in Sources */,
 				56966DAD1F7822B3F00291AE /* WebhookResponses.swift in Sources */,
@@ -13958,13 +14116,46 @@
 				version = 137.7151.12;
 			};
 		};
+		5352D9EE68FFE70DDEAAEA68 /* XCRemoteSwiftPackageReference "hap-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mikeburgh/hap-swift.git";
+			requirement = {
+				branch = macos14;
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		07C3EEE5DFEF1156CC03B2FE /* HAPApple */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5352D9EE68FFE70DDEAAEA68 /* XCRemoteSwiftPackageReference "hap-swift" */;
+			productName = HAPApple;
+		};
+		2083564DCF5AF576E19BCAD6 /* HAPSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5352D9EE68FFE70DDEAAEA68 /* XCRemoteSwiftPackageReference "hap-swift" */;
+			productName = HAPSwift;
+		};
+		580B079BA4E63260A1B785F1 /* HAPApple */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5352D9EE68FFE70DDEAAEA68 /* XCRemoteSwiftPackageReference "hap-swift" */;
+			productName = HAPApple;
+		};
+		A726444284976417DEF72286 /* HAPSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5352D9EE68FFE70DDEAAEA68 /* XCRemoteSwiftPackageReference "hap-swift" */;
+			productName = HAPSwift;
+		};
 		C891028440C5C0E1AB9180F5 /* LiveKitWebRTC */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 4B83A3AD3D02B152E08700AF /* XCRemoteSwiftPackageReference "webrtc-xcframework" */;
 			productName = LiveKitWebRTC;
+		};
+		FC3CEBE6982A4F9F31F8E6E0 /* HAPCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5352D9EE68FFE70DDEAAEA68 /* XCRemoteSwiftPackageReference "hap-swift" */;
+			productName = HAPCore;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/macOSBridge/ActionEngine/ActionEngine.swift
+++ b/macOSBridge/ActionEngine/ActionEngine.swift
@@ -111,8 +111,15 @@ class ActionEngine {
 
         switch resolved {
         case .services(let services):
-            // A projected virtual device resolves here; route it to the store
-            // instead of HomeKit. Real services fall through to HomeKit control.
+            // Name-based virtual routing, and its collision behaviour:
+            // a virtual sensor, once paired, returns through HomeKit under HK's
+            // own id, so we recognise it by NAME (see virtualDevice(in:)). A
+            // virtual sensor whose name matches a resolved service therefore
+            // short-circuits to the store (HAP) BEFORE HomeKit control runs.
+            // Consequence: if a real accessory shares a name with a virtual
+            // sensor, control routes to the virtual one - so virtual-device names
+            // should be kept unique from real accessories. Services with no
+            // virtual match fall through to normal HomeKit control below.
             if let vdev = virtualDevice(in: services) {
                 return applyVirtual(vdev, action: action)
             }
@@ -120,8 +127,9 @@ class ActionEngine {
         case .scene(let scene):
             return executeScene(scene, bridge: bridge)
         case .notFound(let query):
-            // Pre-projection (or resolver miss): match a virtual device by name.
-            // Real devices keep precedence - we only reach here when none matched.
+            // Resolver matched no real device: fall back to a virtual match by
+            // name. Real devices keep precedence - we only reach here when none
+            // matched, so this path cannot shadow a real accessory.
             if let vdev = VirtualDeviceStore.shared.device(named: query) {
                 return applyVirtual(vdev, action: action)
             }

--- a/macOSBridge/ActionEngine/ActionEngine.swift
+++ b/macOSBridge/ActionEngine/ActionEngine.swift
@@ -111,14 +111,55 @@ class ActionEngine {
 
         switch resolved {
         case .services(let services):
+            // A projected virtual device resolves here; route it to the store
+            // instead of HomeKit. Real services fall through to HomeKit control.
+            if let vdev = virtualDevice(in: services) {
+                return applyVirtual(vdev, action: action)
+            }
             return executeOnServices(services, action: action, bridge: bridge)
         case .scene(let scene):
             return executeScene(scene, bridge: bridge)
         case .notFound(let query):
+            // Pre-projection (or resolver miss): match a virtual device by name.
+            // Real devices keep precedence - we only reach here when none matched.
+            if let vdev = VirtualDeviceStore.shared.device(named: query) {
+                return applyVirtual(vdev, action: action)
+            }
             return .error(.targetNotFound(query))
         case .ambiguous(let options):
             return .error(.ambiguousTarget(options.map(\.name)))
         }
+    }
+
+    // MARK: - Virtual devices
+
+    /// A resolved service is a virtual device when its name matches one in the
+    /// VirtualDeviceStore. (Once paired, the device comes back through HomeKit
+    /// with HomeKit's own id, so we match on name rather than identifier.)
+    private func virtualDevice(in services: [ServiceData]) -> VirtualDevice? {
+        for s in services {
+            if let dev = VirtualDeviceStore.shared.device(named: s.name)
+                ?? VirtualDeviceStore.shared.device(named: s.accessoryName) {
+                return dev
+            }
+        }
+        return nil
+    }
+
+    /// Apply a control verb to a read-only virtual sensor: update the store and
+    /// push the new state to HAP. Apple Home then notifies every HomeKit client
+    /// (including ItsyHome itself), so the menu and SSE update via that round-trip.
+    private func applyVirtual(_ device: VirtualDevice, action: Action) -> ActionResult {
+        let newState: Bool
+        if case .toggle = action {
+            newState = VirtualControl.nextState(forToggleFrom: device.state)
+        } else if let b = VirtualControl.boolean(for: action) {
+            newState = b
+        } else {
+            return .error(.executionFailed("\(device.name) is a read-only sensor"))
+        }
+        VirtualControl.setState(device, on: newState)
+        return .success
     }
 
     func executeMultiple(targets: [String], action: Action) -> ActionResult {

--- a/macOSBridge/Automations/Automation.swift
+++ b/macOSBridge/Automations/Automation.swift
@@ -1,0 +1,80 @@
+//
+//  Automation.swift
+//  macOSBridge
+//
+//  Automation model. Triggers / conditions / actions are enums with
+//  associated values - Swift auto-synthesizes Codable + Equatable, and
+//  "extensible" means adding a case plus a handler in AutomationEngine. See
+//  docs/superpowers/specs/2026-06-09-automations-framework-design.md.
+//
+import Foundation
+
+struct Automation: Codable, Equatable, Identifiable {
+    let id: UUID
+    var name: String
+    var enabled: Bool
+    var trigger: AutomationTrigger
+    var conditions: [AutomationCondition]
+    var actions: [AutomationAction]
+
+    /// The single Duration condition, if any (v1 supports one).
+    var durationSeconds: Int? {
+        for c in conditions { if case .duration(let s) = c { return s } }
+        return nil
+    }
+}
+
+enum AutomationTrigger: Codable, Equatable {
+    case accessoryState(AccessoryStateTrigger)
+    // M2: case schedule(ScheduleTrigger), case webhook(WebhookTrigger)
+}
+
+enum AutomationCondition: Codable, Equatable {
+    case duration(seconds: Int)
+}
+
+enum AutomationAction: Codable, Equatable {
+    case setVirtualSensor(SetVirtualSensorAction)
+    // M3: case controlDevice(ControlDeviceAction)
+}
+
+struct AccessoryStateTrigger: Codable, Equatable {
+    var characteristicId: UUID
+    var accessoryName: String         // display + unresolved detection
+    var characteristicLabel: String   // e.g. "Contact"
+    var comparator: Comparator
+    var value: Double
+
+    enum Comparator: String, Codable { case equal, notEqual, greater, less }
+
+    /// Coerce a HomeKit value (Bool/Int/Double/NSNumber) to Double.
+    func currentValueAsDouble(_ raw: Any?) -> Double? {
+        switch raw {
+        case let b as Bool: return b ? 1 : 0
+        case let i as Int: return Double(i)
+        case let d as Double: return d
+        case let n as NSNumber: return n.doubleValue
+        default: return nil
+        }
+    }
+
+    func isSatisfied(by raw: Any?) -> Bool {
+        guard let v = currentValueAsDouble(raw) else { return false }
+        switch comparator {
+        case .equal:    return v == value
+        case .notEqual: return v != value
+        case .greater:  return v > value
+        case .less:     return v < value
+        }
+    }
+}
+
+struct SetVirtualSensorAction: Codable, Equatable {
+    var deviceId: UUID
+    var rePulse: RePulse
+
+    struct RePulse: Codable, Equatable {
+        var enabled: Bool
+        var intervalSeconds: Int
+    }
+}

--- a/macOSBridge/Automations/AutomationDraft.swift
+++ b/macOSBridge/Automations/AutomationDraft.swift
@@ -28,9 +28,15 @@ struct AutomationDraft {
     }
 
     func validationError() -> String? {
-        if name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return "Name is required." }
-        if trigger == nil { return "Choose a trigger." }
-        if actionDeviceId == nil { return "Choose a virtual sensor to drive." }
+        if name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return String(localized: "settings.automations.validation.name_required", defaultValue: "Name is required.", bundle: .macOSBridge)
+        }
+        if trigger == nil {
+            return String(localized: "settings.automations.validation.no_trigger", defaultValue: "Choose a trigger.", bundle: .macOSBridge)
+        }
+        if actionDeviceId == nil {
+            return String(localized: "settings.automations.validation.no_device", defaultValue: "Choose a virtual sensor to drive.", bundle: .macOSBridge)
+        }
         return nil
     }
 

--- a/macOSBridge/Automations/AutomationDraft.swift
+++ b/macOSBridge/Automations/AutomationDraft.swift
@@ -1,0 +1,53 @@
+//
+//  AutomationDraft.swift
+//  macOSBridge
+//
+//  Mutable builder backing the WHEN/FOR/THEN form; validates and produces an Automation.
+//
+import Foundation
+
+struct AutomationDraft {
+    var id: UUID?            // nil = new automation
+    var name: String
+    var trigger: AccessoryStateTrigger?
+    var durationSeconds: Int
+    var actionDeviceId: UUID?
+    var rePulseEnabled: Bool
+    var rePulseInterval: Int
+
+    init(id: UUID? = nil, name: String, trigger: AccessoryStateTrigger?,
+         durationSeconds: Int, actionDeviceId: UUID?,
+         rePulseEnabled: Bool = true, rePulseInterval: Int = 300) {
+        self.id = id
+        self.name = name
+        self.trigger = trigger
+        self.durationSeconds = durationSeconds
+        self.actionDeviceId = actionDeviceId
+        self.rePulseEnabled = rePulseEnabled
+        self.rePulseInterval = rePulseInterval
+    }
+
+    func validationError() -> String? {
+        if name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return "Name is required." }
+        if trigger == nil { return "Choose a trigger." }
+        if actionDeviceId == nil { return "Choose a virtual sensor to drive." }
+        return nil
+    }
+
+    /// Assumes a valid draft (call after validationError() == nil).
+    func build() -> Automation {
+        let actions: [AutomationAction] = actionDeviceId.map {
+            [.setVirtualSensor(SetVirtualSensorAction(
+                deviceId: $0, rePulse: .init(enabled: rePulseEnabled, intervalSeconds: rePulseInterval)))]
+        } ?? []
+        let t = trigger ?? AccessoryStateTrigger(
+            characteristicId: UUID(), accessoryName: "", characteristicLabel: "", comparator: .equal, value: 1)
+        return Automation(
+            id: id ?? UUID(),
+            name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+            enabled: true,
+            trigger: .accessoryState(t),
+            conditions: durationSeconds > 0 ? [.duration(seconds: durationSeconds)] : [],
+            actions: actions)
+    }
+}

--- a/macOSBridge/Automations/AutomationEngine.swift
+++ b/macOSBridge/Automations/AutomationEngine.swift
@@ -65,6 +65,9 @@ final class AutomationEngine {
     func startIfEnabled() {
         onMain {
             guard !self.started else { return }
+            // Automations drive virtual HAP sensors, which only work via the
+            // Apple Home round-trip in HomeKit mode - inert in Home Assistant mode.
+            guard PlatformManager.shared.selectedPlatform == .homeKit else { return }
             guard ProStatusCache.shared.isPro else { return }
             self.started = true
             self.load(AutomationStore.shared.automations)
@@ -181,13 +184,24 @@ final class AutomationEngine {
         }
     }
 
+    /// Momentary OFF duration of a re-pulse "blip". Apple Home automations fire
+    /// on a change, not a held state, so each pulse drives the sensor OFF then
+    /// back ON after this delay to produce a fresh edge. Kept short so it reads
+    /// as a transient blip, not a real "cleared" state.
+    private static let pulseBlipSeconds: TimeInterval = 1
+
     private func startPulse(action: SetVirtualSensorAction, rt: Runtime) {
         rt.pulseTimer?.invalidate()
-        rt.pulseTimer = Timer.scheduledTimer(withTimeInterval: max(1, Double(action.rePulse.intervalSeconds)), repeats: true) { [weak self] _ in
+        // Clamp the interval so a full OFF -> (blip) -> ON cycle always finishes
+        // before the next pulse fires. Without this, an interval shorter than the
+        // blip would interleave the off/on writes and could leave the sensor in
+        // the wrong state.
+        let interval = max(Self.pulseBlipSeconds + 1, Double(action.rePulse.intervalSeconds))
+        rt.pulseTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             guard let self else { return }
-            // Blip: opposite then back, to generate a fresh edge for Apple Home.
+            // Blip: OFF now, back ON after pulseBlipSeconds, so Apple Home sees a fresh edge.
             self.applyActive(action, false)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { self.applyActive(action, true) }
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.pulseBlipSeconds) { self.applyActive(action, true) }
         }
     }
 

--- a/macOSBridge/Automations/AutomationEngine.swift
+++ b/macOSBridge/Automations/AutomationEngine.swift
@@ -1,0 +1,208 @@
+//
+//  AutomationEngine.swift
+//  macOSBridge
+//
+//  Evaluates automations. Taps the characteristic-change chokepoint
+//  (MacOSController.updateMenuItems), arms per-automation duration timers, and on
+//  activation drives a virtual sensor via VirtualControl with a re-pulse loop.
+//  The pure decision (desiredPhase) is split out for testing; timers + actions
+//  wrap it. Main-thread confined.
+//
+import Foundation
+
+/// What a automation wants to do in response to a characteristic value. Pure +
+/// testable; the engine maps these onto timers/actions.
+enum AutomationPhase: Equatable {
+    case idle                  // trigger not satisfied
+    case arming(seconds: Int)  // satisfied, wait for the duration
+    case activeNow             // satisfied, no duration -> activate immediately
+}
+
+enum AutomationEvaluation {
+    /// nil = this characteristic is irrelevant to the automation (leave it as-is).
+    static func desiredPhase(for automation: Automation, characteristic id: UUID, value: Any) -> AutomationPhase? {
+        guard automation.enabled else { return .idle }
+        guard case .accessoryState(let t) = automation.trigger, t.characteristicId == id else { return nil }
+        guard t.isSatisfied(by: value) else { return .idle }
+        if let seconds = automation.durationSeconds { return .arming(seconds: seconds) }
+        return .activeNow
+    }
+}
+
+final class AutomationEngine {
+    static let shared = AutomationEngine()
+
+    /// Reads a characteristic's current value (set from MacOSController) so
+    /// automations whose trigger is already true at launch arm correctly.
+    var valueProvider: ((UUID) -> Any?)?
+
+    /// Test seam: how an active/inactive automation drives its action. Production
+    /// default sets the target virtual sensor's state via VirtualControl.
+    private let applyActive: (SetVirtualSensorAction, Bool) -> Void
+
+    /// Test seam: whether a target virtual sensor still exists.
+    private let deviceExists: (UUID) -> Bool
+
+    private var automations: [Automation] = []
+    private var runtimes: [UUID: Runtime] = [:]
+    private var started = false
+
+    init(applyActive: @escaping (SetVirtualSensorAction, Bool) -> Void = AutomationEngine.defaultApply,
+         deviceExists: @escaping (UUID) -> Bool = AutomationEngine.defaultDeviceExists) {
+        self.applyActive = applyActive
+        self.deviceExists = deviceExists
+    }
+
+    private final class Runtime {
+        var armTimer: Timer?
+        var pulseTimer: Timer?
+        var active = false
+        var armedUntil: Date?
+    }
+
+    // MARK: Lifecycle
+
+    func startIfEnabled() {
+        onMain {
+            guard !self.started else { return }
+            guard ProStatusCache.shared.isPro else { return }
+            self.started = true
+            self.load(AutomationStore.shared.automations)
+        }
+    }
+
+    // MARK: Runtime state (for the UI)
+
+    enum AutomationRuntimeState: Equatable { case idle, armed, active }
+
+    /// When each automation last activated (in-memory; resets on restart).
+    private(set) var lastActivated: [UUID: Date] = [:]
+
+    func runtimeState(automationId: UUID) -> AutomationRuntimeState {
+        guard let rt = runtimes[automationId] else { return .idle }
+        if rt.active { return .active }
+        if rt.armTimer != nil { return .armed }
+        return .idle
+    }
+
+    /// Seconds until an armed automation fires, or nil if not arming.
+    func armedRemaining(automationId: UUID) -> Int? {
+        guard let rt = runtimes[automationId], rt.armTimer != nil, let until = rt.armedUntil else { return nil }
+        return max(0, Int(until.timeIntervalSinceNow.rounded()))
+    }
+
+    func reload() { onMain { if self.started { self.load(AutomationStore.shared.automations) } } }
+
+    func stop() {
+        onMain {
+            for (_, rt) in self.runtimes { rt.armTimer?.invalidate(); rt.pulseTimer?.invalidate() }
+            self.runtimes.removeAll()
+            self.started = false
+        }
+    }
+
+    /// Reset all runtimes and (re)evaluate current values so already-true
+    /// triggers arm. Internal so tests can drive it directly.
+    func load(_ automations: [Automation]) {
+        onMain {
+            for (_, rt) in self.runtimes { rt.armTimer?.invalidate(); rt.pulseTimer?.invalidate() }
+            self.runtimes.removeAll()
+            self.automations = automations
+            for automation in automations where automation.enabled {
+                self.runtimes[automation.id] = Runtime()
+                if case .accessoryState(let t) = automation.trigger,
+                   let current = self.valueProvider?(t.characteristicId) {
+                    self.evaluate(automation: automation, value: current)
+                }
+            }
+        }
+    }
+
+    // MARK: Change handling
+
+    func handleCharacteristicChange(id: UUID, value: Any) {
+        onMain {
+            for automation in self.automations where automation.enabled {
+                if case .accessoryState(let t) = automation.trigger, t.characteristicId == id {
+                    self.evaluate(automation: automation, value: value)
+                }
+            }
+        }
+    }
+
+    private func evaluate(automation: Automation, value: Any) {
+        guard let rt = runtimes[automation.id] else { return }
+        // Skip automations whose target virtual sensor no longer exists - they can't run.
+        if case .setVirtualSensor(let a)? = automation.actions.first, !deviceExists(a.deviceId) {
+            rt.armTimer?.invalidate(); rt.armTimer = nil; rt.armedUntil = nil
+            if rt.active { deactivate(automation: automation, rt: rt) }
+            return
+        }
+        switch AutomationEvaluation.desiredPhase(for: automation, characteristic: triggerCharId(automation), value: value) {
+        case .idle, .none:
+            rt.armTimer?.invalidate(); rt.armTimer = nil; rt.armedUntil = nil
+            if rt.active { deactivate(automation: automation, rt: rt) }
+        case .arming(let seconds):
+            guard !rt.active, rt.armTimer == nil else { return }
+            rt.armedUntil = Date().addingTimeInterval(max(0.01, Double(seconds)))
+            rt.armTimer = Timer.scheduledTimer(withTimeInterval: max(0.01, Double(seconds)), repeats: false) { [weak self, weak rt] _ in
+                guard let self, let rt else { return }
+                rt.armTimer = nil; rt.armedUntil = nil
+                self.activate(automation: automation, rt: rt)
+            }
+        case .activeNow:
+            if !rt.active { activate(automation: automation, rt: rt) }
+        }
+    }
+
+    private func triggerCharId(_ automation: Automation) -> UUID {
+        if case .accessoryState(let t) = automation.trigger { return t.characteristicId }
+        return UUID()
+    }
+
+    // MARK: Activation
+
+    private func activate(automation: Automation, rt: Runtime) {
+        rt.active = true
+        lastActivated[automation.id] = Date()
+        for action in automation.actions {
+            if case .setVirtualSensor(let a) = action {
+                applyActive(a, true)
+                if a.rePulse.enabled { startPulse(action: a, rt: rt) }
+            }
+        }
+    }
+
+    private func deactivate(automation: Automation, rt: Runtime) {
+        rt.active = false
+        rt.pulseTimer?.invalidate(); rt.pulseTimer = nil
+        for action in automation.actions {
+            if case .setVirtualSensor(let a) = action { applyActive(a, false) }
+        }
+    }
+
+    private func startPulse(action: SetVirtualSensorAction, rt: Runtime) {
+        rt.pulseTimer?.invalidate()
+        rt.pulseTimer = Timer.scheduledTimer(withTimeInterval: max(1, Double(action.rePulse.intervalSeconds)), repeats: true) { [weak self] _ in
+            guard let self else { return }
+            // Blip: opposite then back, to generate a fresh edge for Apple Home.
+            self.applyActive(action, false)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { self.applyActive(action, true) }
+        }
+    }
+
+    // MARK: Helpers
+
+    private func onMain(_ work: @escaping () -> Void) {
+        if Thread.isMainThread { work() } else { DispatchQueue.main.async(execute: work) }
+    }
+
+    static func defaultApply(_ action: SetVirtualSensorAction, _ on: Bool) {
+        guard let device = VirtualDeviceStore.shared.device(id: action.deviceId) else { return }
+        VirtualControl.setState(device, on: on)
+    }
+
+    static func defaultDeviceExists(_ id: UUID) -> Bool {
+        VirtualDeviceStore.shared.device(id: id) != nil
+    }
+}

--- a/macOSBridge/Automations/AutomationStore.swift
+++ b/macOSBridge/Automations/AutomationStore.swift
@@ -1,0 +1,59 @@
+//
+//  AutomationStore.swift
+//  macOSBridge
+//
+//  Persisted automations (UserDefaults JSON, the PreferencesManager
+//  pattern, like VirtualDeviceStore).
+//
+import Foundation
+
+final class AutomationStore {
+    static let shared = AutomationStore()
+    static let didChangeNotification = Notification.Name("AutomationStoreDidChange")
+    private static let storageKey = "automationRules"
+
+    private let defaults: UserDefaults
+    private(set) var automations: [Automation]
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: Self.storageKey),
+           let decoded = try? JSONDecoder().decode([Automation].self, from: data) {
+            self.automations = decoded
+        } else {
+            self.automations = []
+        }
+    }
+
+    func automation(id: UUID) -> Automation? { automations.first { $0.id == id } }
+
+    /// Insert or replace by id.
+    func upsert(_ automation: Automation) {
+        if let idx = automations.firstIndex(where: { $0.id == automation.id }) {
+            automations[idx] = automation
+        } else {
+            automations.append(automation)
+        }
+        persist(); notifyChanged()
+    }
+
+    func remove(id: UUID) {
+        automations.removeAll { $0.id == id }
+        persist(); notifyChanged()
+    }
+
+    func setEnabled(_ enabled: Bool, id: UUID) {
+        guard let idx = automations.firstIndex(where: { $0.id == id }) else { return }
+        automations[idx].enabled = enabled
+        persist(); notifyChanged()
+    }
+
+    private func persist() {
+        if let data = try? JSONEncoder().encode(automations) {
+            defaults.set(data, forKey: Self.storageKey)
+        }
+    }
+    private func notifyChanged() {
+        NotificationCenter.default.post(name: Self.didChangeNotification, object: nil)
+    }
+}

--- a/macOSBridge/HAPBridge/FilePairingStore.swift
+++ b/macOSBridge/HAPBridge/FilePairingStore.swift
@@ -1,0 +1,64 @@
+//
+//  FilePairingStore.swift
+//  macOSBridge
+//
+//  File-backed HAP pairing store so controller pairings survive app restarts.
+//  The library's InMemoryPairingStore forgets them every launch, which - with a
+//  changing device ID - leaves HomeKit with stale records and forces a re-pair.
+//
+
+import Foundation
+import HAPSwift
+import os.log
+
+/// Persists pairings (controllerIdentifier -> long-term public key) to a JSON
+/// file. `Data` encodes as base64 in JSON, so the dictionary is Codable as-is.
+/// Methods mirror `InMemoryPairingStore`: synchronous and non-throwing (the
+/// actor isolation satisfies the protocol's `async throws` requirements), with
+/// disk-write failures logged rather than propagated.
+actor FilePairingStore: PairingStore {
+
+    private let fileURL: URL
+    private var pairings: [String: Data]
+    private let logger = os.Logger(subsystem: "com.nickustinov.itsyhome.macOSBridge", category: "HAP")
+
+    /// Computed (mirrors InMemoryPairingStore) - witnesses the protocol's
+    /// `var isPaired: Bool { get async }` via actor isolation.
+    var isPaired: Bool { !pairings.isEmpty }
+
+    init(fileURL: URL) {
+        self.fileURL = fileURL
+        if let data = try? Data(contentsOf: fileURL),
+           let decoded = try? JSONDecoder().decode([String: Data].self, from: data) {
+            self.pairings = decoded
+        } else {
+            self.pairings = [:]
+        }
+    }
+
+    func store(controllerIdentifier: String, publicKey: Data) async throws {
+        pairings[controllerIdentifier] = publicKey
+        persist()
+    }
+
+    func publicKey(for controllerIdentifier: String) async throws -> Data? {
+        pairings[controllerIdentifier]
+    }
+
+    func remove(controllerIdentifier: String) async throws {
+        pairings.removeValue(forKey: controllerIdentifier)
+        persist()
+    }
+
+    func listPairings() async throws -> [(identifier: String, publicKey: Data)] {
+        pairings.map { (identifier: $0.key, publicKey: $0.value) }
+    }
+
+    private func persist() {
+        do {
+            try JSONEncoder().encode(pairings).write(to: fileURL, options: .atomic)
+        } catch {
+            logger.error("FilePairingStore persist failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/macOSBridge/HAPBridge/HAPIdentityKeychain.swift
+++ b/macOSBridge/HAPBridge/HAPIdentityKeychain.swift
@@ -1,0 +1,57 @@
+//
+//  HAPIdentityKeychain.swift
+//  macOSBridge
+//
+//  Stores the HAP bridge's long-term Ed25519 private key in the Keychain rather
+//  than as a plaintext file in Application Support. The key proves the bridge's
+//  identity to already-paired Apple Home controllers, so it is the most
+//  sensitive part of the pairing triad. This matches how the app already keeps
+//  Home Assistant credentials in the Keychain (see HAAuthManager).
+//
+
+import Foundation
+import Security
+
+enum HAPIdentityKeychain {
+
+    private static let service = "com.nickustinov.itsyhome.hap"
+    private static let account = "bridge-identity"
+
+    static func load() -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data else {
+            return nil
+        }
+        return data
+    }
+
+    static func save(_ data: Data) {
+        // Delete-then-add so a re-save never hits errSecDuplicateItem.
+        delete()
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    static func delete() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/macOSBridge/HAPBridge/HAPService+CarbonDioxide.swift
+++ b/macOSBridge/HAPBridge/HAPService+CarbonDioxide.swift
@@ -1,0 +1,33 @@
+//
+//  HAPService+CarbonDioxide.swift
+//  macOSBridge
+//
+//  Carbon dioxide sensor support. hap-swift (main) defines the other six
+//  read-only sensor types but not CO2, so we add the service type (HomeKit
+//  short UUID "97"), the detected characteristic ("92"), and a factory that
+//  mirrors hap-swift's own sensor factories exactly.
+//
+import HAPCore
+
+extension HAPServiceType {
+    /// HomeKit Carbon Dioxide Sensor service (00000097-...).
+    public static let carbonDioxideSensor = HAPServiceType(rawValue: "97")
+}
+
+extension HAPCharacteristicType {
+    /// HomeKit Carbon Dioxide Detected characteristic (00000092-...).
+    public static let carbonDioxideDetected = HAPCharacteristicType(rawValue: "92")
+}
+
+extension HAPService {
+    /// Read-only carbon dioxide sensor, mirroring hap-swift's sensor factories.
+    public static func carbonDioxideSensor(startIID: UInt64) -> HAPService {
+        HAPService(type: .carbonDioxideSensor, characteristics: [
+            HAPCharacteristic(
+                iid: startIID, type: .carbonDioxideDetected, value: .uint8(0),
+                permissions: [.read, .notify], format: .uint8,
+                minValue: 0, maxValue: 1
+            ),
+        ])
+    }
+}

--- a/macOSBridge/HAPBridge/VirtualBridgeService.swift
+++ b/macOSBridge/HAPBridge/VirtualBridgeService.swift
@@ -17,6 +17,12 @@ import os.log
 // `HAPCore.AccessoryInfo` to disambiguate.
 private typealias HAPInfo = HAPCore.AccessoryInfo
 
+// Main-actor-confined: all mutable state (`bridge`, `service`, `started`,
+// `stateIIDs`, `status`) is touched only from the main actor, so interleaved
+// start/stop/addDevice/setState calls cannot race. The sync entry points the UI
+// and MacOSController call without `await` (`startIfEnabled`, `setupCode`,
+// `status`) are `nonisolated` so non-main-actor callers still reach them.
+@MainActor
 final class VirtualBridgeService {
 
     static let shared = VirtualBridgeService()
@@ -45,14 +51,20 @@ final class VirtualBridgeService {
     }
 
     /// The user-facing setup code (XXX-XX-XXX), persisted; shown in Settings.
-    var setupCode: String { PreferencesManager.shared.virtualBridgeSetupCode }
+    /// `nonisolated`: only reads PreferencesManager, so the UI reads it directly.
+    nonisolated var setupCode: String { PreferencesManager.shared.virtualBridgeSetupCode }
 
     // MARK: Lifecycle
 
-    /// Start only when the user enabled the bridge (and Pro is active). Wired
-    /// into ProManager and the Settings toggle.
-    func startIfEnabled() {
-        guard ProStatusCache.shared.isPro, PreferencesManager.shared.virtualBridgeEnabled else { return }
+    /// Start only when the user enabled the bridge, Pro is active, and we are in
+    /// HomeKit mode. The virtual sensors depend on the Apple Home -> HomeKit
+    /// notify -> ItsyHome round-trip, which does not exist in Home Assistant
+    /// mode, so the bridge is HomeKit-only. `nonisolated` so the sync callers
+    /// (MacOSController, ProManager, the Settings toggle) reach it without await.
+    nonisolated func startIfEnabled() {
+        guard PlatformManager.shared.selectedPlatform == .homeKit,
+              ProStatusCache.shared.isPro,
+              PreferencesManager.shared.virtualBridgeEnabled else { return }
         Task { await start() }
     }
 
@@ -182,18 +194,18 @@ final class VirtualBridgeService {
     }
 
     private static func stableIdentity() -> HAPIdentity {
-        let url = supportDir().appendingPathComponent("identity")
-        if let data = try? Data(contentsOf: url), let identity = try? HAPIdentity(privateKeyData: data) {
+        if let data = HAPIdentityKeychain.load(), let identity = try? HAPIdentity(privateKeyData: data) {
             return identity
         }
         let identity = HAPIdentity()
-        try? identity.privateKeyData.write(to: url, options: .atomic)
+        HAPIdentityKeychain.save(identity.privateKeyData)
         return identity
     }
 
     private static func deletePersistentState() {
+        HAPIdentityKeychain.delete()
         let dir = supportDir()
-        for name in ["deviceID", "identity", "pairings.json"] {
+        for name in ["deviceID", "pairings.json"] {
             try? FileManager.default.removeItem(at: dir.appendingPathComponent(name))
         }
     }

--- a/macOSBridge/HAPBridge/VirtualBridgeService.swift
+++ b/macOSBridge/HAPBridge/VirtualBridgeService.swift
@@ -1,0 +1,209 @@
+//
+//  VirtualBridgeService.swift
+//  macOSBridge
+//
+//  Publishes the VirtualDeviceStore's devices over HAP (acumen-dev/hap-swift)
+//  as bridged accessories. State is driven by webhooks/rules via setState; the
+//  identity triad (deviceID, identity, pairings) persists so pairings survive
+//  restarts. See docs/superpowers/specs/2026-06-08-virtual-device-framework-design.md.
+//
+import Foundation
+import HAPCore
+import HAPSwift
+import HAPApple
+import os.log
+
+// `macOSBridge` has its own `AccessoryInfo`, so the HAP one is referred to as
+// `HAPCore.AccessoryInfo` to disambiguate.
+private typealias HAPInfo = HAPCore.AccessoryInfo
+
+final class VirtualBridgeService {
+
+    static let shared = VirtualBridgeService()
+
+    static let statusChangedNotification = Notification.Name("virtualBridgeStatusChanged")
+
+    enum Status: Equatable { case stopped, running, error(String) }
+    private(set) var status: Status = .stopped {
+        didSet { NotificationCenter.default.post(name: Self.statusChangedNotification, object: nil) }
+    }
+
+    private let logger = os.Logger(subsystem: "com.nickustinov.itsyhome.macOSBridge", category: "HAP")
+    private let store: VirtualDeviceStore
+
+    // A fresh bridge is built per start() so enable/disable cycles never collide
+    // on already-registered accessory IDs.
+    private var bridge: HAPBridge?
+    private var service: AppleHAPService?
+    private var started = false
+
+    /// aid -> resolved detected-characteristic iid (filled after addAccessory).
+    private var stateIIDs: [UInt64: UInt64] = [:]
+
+    private init(store: VirtualDeviceStore = .shared) {
+        self.store = store
+    }
+
+    /// The user-facing setup code (XXX-XX-XXX), persisted; shown in Settings.
+    var setupCode: String { PreferencesManager.shared.virtualBridgeSetupCode }
+
+    // MARK: Lifecycle
+
+    /// Start only when the user enabled the bridge (and Pro is active). Wired
+    /// into ProManager and the Settings toggle.
+    func startIfEnabled() {
+        guard ProStatusCache.shared.isPro, PreferencesManager.shared.virtualBridgeEnabled else { return }
+        Task { await start() }
+    }
+
+    /// Publish all current devices and start advertising. Idempotent. No-op if
+    /// the store is empty (an accessory-less bridge is pointless) - publishing
+    /// begins when the first device is added via `addDevice`.
+    func start() async {
+        guard !started else { return }
+        guard !store.devices.isEmpty else { return }
+        started = true
+
+        let bridge = HAPBridge(info: HAPInfo(
+            name: "Itsyhome Bridge", manufacturer: "Itsyhome",
+            model: "VirtualBridge", serialNumber: "VB-0001", firmwareRevision: "1.0"))
+        self.bridge = bridge
+
+        do {
+            for device in store.devices { await publish(device, on: bridge) }
+
+            let service = AppleHAPService(
+                bridge: bridge,
+                setupCode: setupCode,
+                deviceID: Self.stableDeviceID(),
+                identity: Self.stableIdentity(),
+                pairingStore: FilePairingStore(fileURL: Self.supportDir().appendingPathComponent("pairings.json")))
+            self.service = service
+            try await service.start()
+            status = .running
+            logger.info("HAP bridge started, \(self.store.devices.count) device(s)")
+        } catch {
+            started = false
+            self.bridge = nil
+            self.service = nil
+            status = .error(error.localizedDescription)
+            logger.error("HAP bridge failed to start: \(error.localizedDescription)")
+        }
+    }
+
+    func stop() async {
+        await service?.stop()
+        service = nil
+        bridge = nil
+        stateIIDs.removeAll()
+        started = false
+        status = .stopped
+    }
+
+    /// Add a device live (or boot the bridge if this is the first one).
+    func addDevice(_ device: VirtualDevice) async {
+        guard started, let bridge else { await start(); return }
+        await publish(device, on: bridge)
+    }
+
+    func removeDevice(aid: UInt64) async {
+        guard let bridge else { return }
+        await bridge.removeAccessory(aid: aid)   // triggers re-advertise via change handler
+        stateIIDs[aid] = nil
+    }
+
+    /// Re-publish a device after an edit (name/type/role changed): remove the
+    /// old accessory at its aid and add it back with the same aid.
+    func updateDevice(_ device: VirtualDevice) async {
+        guard started, let bridge else { return }
+        await bridge.removeAccessory(aid: device.aid)
+        stateIIDs[device.aid] = nil
+        await publish(device, on: bridge)
+    }
+
+    /// Full reset: stop, wipe the persisted identity triad + setup code, then
+    /// start fresh so the bridge advertises as a brand-new, unpaired accessory.
+    /// The user then removes the stale tile in Apple Home and re-adds it.
+    func resetPairing() async {
+        await stop()
+        Self.deletePersistentState()
+        PreferencesManager.shared.resetVirtualBridgeSetupCode()
+        await start()
+    }
+
+    // MARK: State
+
+    /// Push a device's state outward to Apple Home. The store is updated by the
+    /// caller (ActionEngine); this only mirrors it onto HAP.
+    func setState(aid: UInt64, on: Bool) async {
+        guard let bridge, let iid = stateIIDs[aid] else { return }
+        await bridge.updateCharacteristic(aid: aid, iid: iid, value: .uint8(on ? 1 : 0))
+    }
+
+    // MARK: Publishing
+
+    private func publish(_ device: VirtualDevice, on bridge: HAPBridge) async {
+        let info = HAPInfo(
+            name: device.name, manufacturer: "Itsyhome",
+            model: "Virtual-\(device.type.rawValue)", serialNumber: "VD-\(device.key)",
+            firmwareRevision: "1.0")
+        let aid = await bridge.addAccessory(
+            info: info,
+            services: [device.type.makeHAPService(startIID: 2)],
+            aid: device.aid)
+        if let iid = await Self.detectedIID(in: bridge, aid: aid, type: device.type) {
+            stateIIDs[aid] = iid
+            await bridge.updateCharacteristic(aid: aid, iid: iid, value: .uint8(device.state ? 1 : 0))
+        }
+    }
+
+    /// Find the detected-characteristic IID after addAccessory renumbers IIDs.
+    /// Exposed (static) for testing.
+    static func detectedIID(in bridge: HAPBridge, aid: UInt64, type: VirtualSensorType) async -> UInt64? {
+        for acc in await bridge.accessoryDatabase() where acc.aid == aid {
+            for svc in acc.services {
+                for char in svc.characteristics where char.type == type.detectedCharacteristic {
+                    return char.iid
+                }
+            }
+        }
+        return nil
+    }
+
+    // MARK: Persistence (identity triad)
+
+    private static func stableDeviceID() -> String {
+        let url = supportDir().appendingPathComponent("deviceID")
+        if let data = try? Data(contentsOf: url),
+           let id = String(data: data, encoding: .utf8), !id.isEmpty { return id }
+        let id = (0..<6).map { _ in String(format: "%02X", Int.random(in: 0...255)) }.joined(separator: ":")
+        try? Data(id.utf8).write(to: url, options: .atomic)
+        return id
+    }
+
+    private static func stableIdentity() -> HAPIdentity {
+        let url = supportDir().appendingPathComponent("identity")
+        if let data = try? Data(contentsOf: url), let identity = try? HAPIdentity(privateKeyData: data) {
+            return identity
+        }
+        let identity = HAPIdentity()
+        try? identity.privateKeyData.write(to: url, options: .atomic)
+        return identity
+    }
+
+    private static func deletePersistentState() {
+        let dir = supportDir()
+        for name in ["deviceID", "identity", "pairings.json"] {
+            try? FileManager.default.removeItem(at: dir.appendingPathComponent(name))
+        }
+    }
+
+    private static func supportDir() -> URL {
+        let base = (try? FileManager.default.url(
+            for: .applicationSupportDirectory, in: .userDomainMask,
+            appropriateFor: nil, create: true)) ?? FileManager.default.temporaryDirectory
+        let dir = base.appendingPathComponent("Itsyhome/hap", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/macOSBridge/HAPBridge/VirtualControl.swift
+++ b/macOSBridge/HAPBridge/VirtualControl.swift
@@ -1,0 +1,34 @@
+//
+//  VirtualControl.swift
+//  macOSBridge
+//
+//  Maps ItsyHome's control verbs onto a read-only virtual sensor's boolean
+//  state, so virtual devices respond to the same on/off/toggle/open/close
+//  endpoints as real accessories (no /virtual namespace).
+//
+import Foundation
+
+enum VirtualControl {
+    /// on -> true, off -> false, open (setPosition 100) -> true,
+    /// close (setPosition 0) -> false, other positions -> >= 50.
+    /// Returns nil for actions that do not apply to a binary sensor.
+    static func boolean(for action: Action) -> Bool? {
+        switch action {
+        case .turnOn: return true
+        case .turnOff: return false
+        case .setPosition(let p): return p >= 50
+        default: return nil
+        }
+    }
+
+    static func nextState(forToggleFrom current: Bool) -> Bool { !current }
+
+    /// Set a virtual device's state: update the store and push to HAP. Apple
+    /// Home then notifies HomeKit clients (including ItsyHome), so the menu and
+    /// events feed update via the round-trip. Used by both the webhook verbs
+    /// and the Settings per-device toggle.
+    static func setState(_ device: VirtualDevice, on: Bool) {
+        VirtualDeviceStore.shared.setState(id: device.id, on: on)
+        Task { await VirtualBridgeService.shared.setState(aid: device.aid, on: on) }
+    }
+}

--- a/macOSBridge/HAPBridge/VirtualDevice.swift
+++ b/macOSBridge/HAPBridge/VirtualDevice.swift
@@ -76,13 +76,26 @@ extension VirtualSensorType {
     /// The state word shown to the user for each kind (1 = active, 0 = resting).
     func stateWord(on: Bool) -> String {
         switch self {
-        case .contact:        return on ? "Open" : "Closed"
-        case .motion:         return on ? "Motion" : "Clear"
-        case .occupancy:      return on ? "Occupied" : "Clear"
-        case .leak:           return on ? "Leak" : "Dry"
-        case .smoke:          return on ? "Smoke" : "Clear"
-        case .carbonMonoxide: return on ? "CO" : "Clear"
-        case .carbonDioxide:  return on ? "CO\u{2082}" : "Clear"
+        case .contact:        return on ? String(localized: "sensor.state.contact.open", defaultValue: "Open", bundle: .macOSBridge) : String(localized: "sensor.state.contact.closed", defaultValue: "Closed", bundle: .macOSBridge)
+        case .motion:         return on ? String(localized: "sensor.state.motion.on", defaultValue: "Motion", bundle: .macOSBridge) : String(localized: "sensor.state.motion.off", defaultValue: "Clear", bundle: .macOSBridge)
+        case .occupancy:      return on ? String(localized: "sensor.state.occupancy.on", defaultValue: "Occupied", bundle: .macOSBridge) : String(localized: "sensor.state.occupancy.off", defaultValue: "Clear", bundle: .macOSBridge)
+        case .leak:           return on ? String(localized: "sensor.state.leak.on", defaultValue: "Leak", bundle: .macOSBridge) : String(localized: "sensor.state.leak.off", defaultValue: "Dry", bundle: .macOSBridge)
+        case .smoke:          return on ? String(localized: "sensor.state.smoke.on", defaultValue: "Smoke", bundle: .macOSBridge) : String(localized: "sensor.state.smoke.off", defaultValue: "Clear", bundle: .macOSBridge)
+        case .carbonMonoxide: return on ? String(localized: "sensor.state.carbon_monoxide.on", defaultValue: "CO", bundle: .macOSBridge) : String(localized: "sensor.state.carbon_monoxide.off", defaultValue: "Clear", bundle: .macOSBridge)
+        case .carbonDioxide:  return on ? String(localized: "sensor.state.carbon_dioxide.on", defaultValue: "CO\u{2082}", bundle: .macOSBridge) : String(localized: "sensor.state.carbon_dioxide.off", defaultValue: "Clear", bundle: .macOSBridge)
+        }
+    }
+
+    /// The localized sensor-type name shown in pickers and summaries.
+    var displayName: String {
+        switch self {
+        case .contact:        return String(localized: "sensor.type.contact", defaultValue: "Contact", bundle: .macOSBridge)
+        case .motion:         return String(localized: "sensor.type.motion", defaultValue: "Motion", bundle: .macOSBridge)
+        case .occupancy:      return String(localized: "sensor.type.occupancy", defaultValue: "Occupancy", bundle: .macOSBridge)
+        case .leak:           return String(localized: "sensor.type.leak", defaultValue: "Leak", bundle: .macOSBridge)
+        case .smoke:          return String(localized: "sensor.type.smoke", defaultValue: "Smoke", bundle: .macOSBridge)
+        case .carbonMonoxide: return String(localized: "sensor.type.carbon_monoxide", defaultValue: "Carbon Monoxide", bundle: .macOSBridge)
+        case .carbonDioxide:  return String(localized: "sensor.type.carbon_dioxide", defaultValue: "Carbon Dioxide", bundle: .macOSBridge)
         }
     }
 

--- a/macOSBridge/HAPBridge/VirtualDevice.swift
+++ b/macOSBridge/HAPBridge/VirtualDevice.swift
@@ -1,0 +1,110 @@
+//
+//  VirtualDevice.swift
+//  macOSBridge
+//
+//  Model for a user-defined virtual sensor published over HAP. Read-only in
+//  v1; `state` is the last known value. Persisted via VirtualDeviceStore, so
+//  every Codable raw value here is a stable on-disk contract.
+//
+import Foundation
+import HAPCore
+
+/// The seven read-only binary sensor types ItsyHome can publish.
+enum VirtualSensorType: String, Codable, CaseIterable, Equatable {
+    case contact, motion, occupancy, leak, smoke, carbonMonoxide, carbonDioxide
+}
+
+/// Cosmetic role for a contact sensor: drives ItsyHome's icon + wording only.
+/// HomeKit still sees a plain contact sensor. Nil/ignored for other types.
+enum ContactRole: String, Codable, CaseIterable, Equatable {
+    case generic, door, window
+}
+
+struct VirtualDevice: Codable, Equatable, Identifiable {
+    let id: UUID
+    var key: String          // immutable-by-default URL slug
+    var name: String         // display name, unique vs real devices
+    var type: VirtualSensorType
+    var role: ContactRole?   // only meaningful when type == .contact
+    var room: String?        // ItsyHome grouping only (not pushed to HomeKit)
+    var aid: UInt64          // persisted HAP accessory id
+    var state: Bool          // last known state
+
+    /// URL-safe slug: lowercase, alphanumerics, runs of other chars -> single "-".
+    static func slug(from name: String) -> String {
+        let lowered = name.lowercased()
+        var out = ""
+        var lastDash = false
+        for ch in lowered {
+            if ch.isLetter || ch.isNumber {
+                out.append(ch); lastDash = false
+            } else if !lastDash {
+                out.append("-"); lastDash = true
+            }
+        }
+        return out.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+}
+
+extension VirtualSensorType {
+    /// hap-swift factory for this sensor (carbonDioxide uses our local factory).
+    func makeHAPService(startIID: UInt64) -> HAPService {
+        switch self {
+        case .contact:        return .contactSensor(startIID: startIID)
+        case .motion:         return .motionSensor(startIID: startIID)
+        case .occupancy:      return .occupancySensor(startIID: startIID)
+        case .leak:           return .leakSensor(startIID: startIID)
+        case .smoke:          return .smokeSensor(startIID: startIID)
+        case .carbonMonoxide: return .carbonMonoxideSensor(startIID: startIID)
+        case .carbonDioxide:  return .carbonDioxideSensor(startIID: startIID)
+        }
+    }
+
+    /// The hap-swift characteristic type whose IID we read back after addAccessory.
+    var detectedCharacteristic: HAPCharacteristicType {
+        switch self {
+        case .contact:        return .contactSensorState
+        case .motion:         return .motionDetected
+        case .occupancy:      return .occupancyDetected
+        case .leak:           return .leakDetected
+        case .smoke:          return .smokeDetected
+        case .carbonMonoxide: return .carbonMonoxideDetected
+        case .carbonDioxide:  return .carbonDioxideDetected
+        }
+    }
+
+    /// The state word shown to the user for each kind (1 = active, 0 = resting).
+    func stateWord(on: Bool) -> String {
+        switch self {
+        case .contact:        return on ? "Open" : "Closed"
+        case .motion:         return on ? "Motion" : "Clear"
+        case .occupancy:      return on ? "Occupied" : "Clear"
+        case .leak:           return on ? "Leak" : "Dry"
+        case .smoke:          return on ? "Smoke" : "Clear"
+        case .carbonMonoxide: return on ? "CO" : "Clear"
+        case .carbonDioxide:  return on ? "CO\u{2082}" : "Clear"
+        }
+    }
+
+    /// Life-safety sensors that Apple Home can raise critical alerts for.
+    var isCriticalAlertType: Bool {
+        switch self {
+        case .leak, .smoke, .carbonMonoxide, .carbonDioxide: return true
+        case .contact, .motion, .occupancy: return false
+        }
+    }
+
+    /// Full HomeKit service-type UUID string used when projecting into MenuData.
+    /// Maps to the constants in Itsyhome/Shared/BridgeProtocols.swift `ServiceTypes`.
+    var homeKitServiceType: String {
+        switch self {
+        case .contact:        return ServiceTypes.contactSensor
+        case .motion:         return ServiceTypes.motionSensor
+        case .occupancy:      return ServiceTypes.occupancySensor
+        case .leak:           return ServiceTypes.leakSensor
+        case .smoke:          return ServiceTypes.smokeSensor
+        case .carbonMonoxide: return ServiceTypes.carbonMonoxideSensor
+        case .carbonDioxide:  return ServiceTypes.carbonDioxideSensor
+        }
+    }
+}

--- a/macOSBridge/HAPBridge/VirtualDeviceStore.swift
+++ b/macOSBridge/HAPBridge/VirtualDeviceStore.swift
@@ -1,0 +1,126 @@
+//
+//  VirtualDeviceStore.swift
+//  macOSBridge
+//
+//  Source of truth for virtual devices. Persists a list of VirtualDevice to
+//  UserDefaults as JSON (the PreferencesManager pattern). AIDs start at 2 (the
+//  HAP bridge itself is aid 1) and are never reused while another device is
+//  live, so the published accessory layout stays stable.
+//
+import Foundation
+
+final class VirtualDeviceStore {
+    static let shared = VirtualDeviceStore()
+
+    static let didChangeNotification = Notification.Name("VirtualDeviceStoreDidChange")
+    private static let storageKey = "virtualDevices"
+    private static let nextAidKey = "virtualDevicesNextAid"
+
+    private let defaults: UserDefaults
+    private(set) var devices: [VirtualDevice]
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: Self.storageKey),
+           let decoded = try? JSONDecoder().decode([VirtualDevice].self, from: data) {
+            self.devices = decoded
+        } else {
+            self.devices = []
+        }
+    }
+
+    enum StoreError: LocalizedError {
+        case duplicateName(String)
+        var errorDescription: String? {
+            switch self {
+            case .duplicateName(let n): return "A device named \"\(n)\" already exists."
+            }
+        }
+    }
+
+    // MARK: Queries
+
+    func device(id: UUID) -> VirtualDevice? { devices.first { $0.id == id } }
+    func device(key: String) -> VirtualDevice? { devices.first { $0.key == key } }
+
+    /// Case-insensitive name match against virtual devices.
+    func device(named name: String) -> VirtualDevice? {
+        let q = name.lowercased()
+        return devices.first { $0.name.lowercased() == q }
+    }
+
+    // MARK: Mutations
+
+    @discardableResult
+    func add(name: String, type: VirtualSensorType, role: ContactRole?, room: String?) throws -> VirtualDevice {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if devices.contains(where: { $0.name.lowercased() == trimmed.lowercased() }) {
+            throw StoreError.duplicateName(trimmed)
+        }
+        let device = VirtualDevice(
+            id: UUID(),
+            key: uniqueKey(base: VirtualDevice.slug(from: trimmed)),
+            name: trimmed,
+            type: type,
+            role: type == .contact ? (role ?? .generic) : nil,
+            room: room,
+            aid: nextAid(),
+            state: false
+        )
+        devices.append(device)
+        persist()
+        notifyChanged()
+        return device
+    }
+
+    func update(_ device: VirtualDevice) {
+        guard let idx = devices.firstIndex(where: { $0.id == device.id }) else { return }
+        devices[idx] = device
+        persist()
+        notifyChanged()
+    }
+
+    func remove(id: UUID) {
+        devices.removeAll { $0.id == id }
+        persist()
+        notifyChanged()
+    }
+
+    /// State changes persist but do NOT post didChangeNotification - they don't
+    /// alter the device list, so the Settings list shouldn't rebuild (which would
+    /// flicker the row you just tapped).
+    func setState(id: UUID, on: Bool) {
+        guard let idx = devices.firstIndex(where: { $0.id == id }) else { return }
+        guard devices[idx].state != on else { return }
+        devices[idx].state = on
+        persist()
+    }
+
+    // MARK: Helpers
+
+    private func uniqueKey(base: String) -> String {
+        let root = base.isEmpty ? "device" : base
+        if !devices.contains(where: { $0.key == root }) { return root }
+        var n = 2
+        while devices.contains(where: { $0.key == "\(root)-\(n)" }) { n += 1 }
+        return "\(root)-\(n)"
+    }
+
+    /// Monotonic aid counter persisted separately so removed aids are never reused.
+    private func nextAid() -> UInt64 {
+        let stored = UInt64(defaults.integer(forKey: Self.nextAidKey))
+        let aid = max(stored, 2)
+        defaults.set(Int(aid + 1), forKey: Self.nextAidKey)
+        return aid
+    }
+
+    private func persist() {
+        if let data = try? JSONEncoder().encode(devices) {
+            defaults.set(data, forKey: Self.storageKey)
+        }
+    }
+
+    private func notifyChanged() {
+        NotificationCenter.default.post(name: Self.didChangeNotification, object: nil)
+    }
+}

--- a/macOSBridge/HAPBridge/VirtualDeviceStore.swift
+++ b/macOSBridge/HAPBridge/VirtualDeviceStore.swift
@@ -33,7 +33,7 @@ final class VirtualDeviceStore {
         case duplicateName(String)
         var errorDescription: String? {
             switch self {
-            case .duplicateName(let n): return "A device named \"\(n)\" already exists."
+            case .duplicateName(let n): return String(localized: "error.virtual_device.duplicate_name", defaultValue: "A device named \"\(n)\" already exists.", bundle: .macOSBridge)
             }
         }
     }

--- a/macOSBridge/MacOSController+MenuUpdates.swift
+++ b/macOSBridge/MacOSController+MenuUpdates.swift
@@ -12,10 +12,13 @@ extension MacOSController {
     // MARK: - Menu Updates
 
     func updateMenuItems(for characteristicId: UUID, value: Any, isLocalChange: Bool) {
-        // Pinned status items (visible in the menu bar) and SSE clients always
-        // need live updates, regardless of whether the dropdown is open.
+        // Pinned status items (visible in the menu bar), SSE clients, and the
+        // automation engine always need live updates, regardless of whether the
+        // dropdown is open: the engine evaluates state-duration triggers (e.g.
+        // "door open for 15 min") continuously, not just while the menu is open.
         updatePinnedStatusItems(for: characteristicId, value: value)
         WebhookServer.shared.publishCharacteristicChange(characteristicId: characteristicId, value: value)
+        AutomationEngine.shared.handleCharacteristicChange(id: characteristicId, value: value)
 
         // The dropdown's rows aren't visible while it's closed, and menuWillOpen
         // re-reads every characteristic via refreshCharacteristics(), so skip the

--- a/macOSBridge/MacOSController.swift
+++ b/macOSBridge/MacOSController.swift
@@ -811,6 +811,14 @@ public class MacOSController: NSObject, iOS2Mac, NSMenuDelegate, PlatformPickerD
 
         WebhookServer.shared.configure(actionEngine: actionEngine)
         WebhookServer.shared.rebuildCharacteristicIndex(from: data)
+
+        // Publish the virtual HAP bridge if the user enabled it (idempotent).
+        VirtualBridgeService.shared.startIfEnabled()
+
+        // Rules engine: give it a way to read current characteristic values, then
+        // start it (idempotent once running).
+        AutomationEngine.shared.valueProvider = { [weak self] id in self?.getCharacteristicValue(identifier: id) }
+        AutomationEngine.shared.startIfEnabled()
         let camerasEnabled = PreferencesManager.shared.camerasEnabled
         let isPro = ProStatusCache.shared.isPro
         let shouldShow = data.hasCameras && camerasEnabled && isPro

--- a/macOSBridge/Pro/ProManager.swift
+++ b/macOSBridge/Pro/ProManager.swift
@@ -119,9 +119,13 @@ final class ProManager: ObservableObject {
         if hasProEntitlement {
             CloudSyncManager.shared.startListening()
             WebhookServer.shared.startIfEnabled()
+            VirtualBridgeService.shared.startIfEnabled()
+            AutomationEngine.shared.startIfEnabled()
         } else {
             CloudSyncManager.shared.stopListening()
             WebhookServer.shared.stop()
+            Task { await VirtualBridgeService.shared.stop() }
+            AutomationEngine.shared.stop()
         }
     }
 

--- a/macOSBridge/Resources/Localizable.xcstrings
+++ b/macOSBridge/Resources/Localizable.xcstrings
@@ -5699,6 +5699,314 @@
         }
       }
     },
+    "device.sensor.clear" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frei"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normal"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normal"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normale"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正常"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정상"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Czysto"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Normal"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чисто"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正常"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正常"
+          }
+        }
+      }
+    },
+    "device.sensor.co" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "CO"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO"
+          }
+        }
+      }
+    },
+    "device.sensor.co2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO2"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "CO2"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO2"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO2"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO2"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO2"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO2"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO2"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO2"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO2"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO2"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CO2"
+          }
+        }
+      }
+    },
+    "device.sensor.dry" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trocken"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dry"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seco"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sec"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Asciutto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "乾燥"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건조"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sucho"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seco"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сухо"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "干燥"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "乾燥"
+          }
+        }
+      }
+    },
     "device.sensor.humidity" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -5772,6 +6080,468 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "濕度"
+          }
+        }
+      }
+    },
+    "device.sensor.leak" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leck"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Leak"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fuga"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fuite"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Perdita"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "漏水"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "누수"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyciek"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vazamento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Протечка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "漏水"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "漏水"
+          }
+        }
+      }
+    },
+    "device.sensor.motion" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bewegung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Motion"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Movimiento"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mouvement"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Movimento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動き"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "움직임"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ruch"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Movimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Движение"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有移动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有移動"
+          }
+        }
+      }
+    },
+    "device.sensor.occupied" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Belegt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Occupied"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocupado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Occupé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Occupato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在室"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "재실"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zajęte"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocupado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Занято"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有人"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有人"
+          }
+        }
+      }
+    },
+    "device.sensor.off" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aus"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Off"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desactivado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactivé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inattivo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "꺼짐"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wył."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desligado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выкл."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關"
+          }
+        }
+      }
+    },
+    "device.sensor.on" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "On"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attivo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "켜짐"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wł."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ligado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вкл."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開"
+          }
+        }
+      }
+    },
+    "device.sensor.smoke" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rauch"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Smoke"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Humo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fumée"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fumo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "煙"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연기"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dym"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fumaça"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дым"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "烟雾"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "煙霧"
           }
         }
       }
@@ -6157,6 +6927,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "開啟中..."
+          }
+        }
+      }
+    },
+    "error.virtual_device.duplicate_name" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A device named \"%@\" already exists."
           }
         }
       }
@@ -9087,6 +9868,259 @@
         }
       }
     },
+    "sensor.state.carbon_dioxide.off" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear"
+          }
+        }
+      }
+    },
+    "sensor.state.carbon_dioxide.on" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "CO₂"
+          }
+        }
+      }
+    },
+    "sensor.state.carbon_monoxide.off" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear"
+          }
+        }
+      }
+    },
+    "sensor.state.carbon_monoxide.on" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "CO"
+          }
+        }
+      }
+    },
+    "sensor.state.contact.closed" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Closed"
+          }
+        }
+      }
+    },
+    "sensor.state.contact.open" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open"
+          }
+        }
+      }
+    },
+    "sensor.state.generic.off" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Off"
+          }
+        }
+      }
+    },
+    "sensor.state.generic.on" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "On"
+          }
+        }
+      }
+    },
+    "sensor.state.leak.off" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dry"
+          }
+        }
+      }
+    },
+    "sensor.state.leak.on" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Leak"
+          }
+        }
+      }
+    },
+    "sensor.state.motion.off" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear"
+          }
+        }
+      }
+    },
+    "sensor.state.motion.on" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Motion"
+          }
+        }
+      }
+    },
+    "sensor.state.occupancy.off" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear"
+          }
+        }
+      }
+    },
+    "sensor.state.occupancy.on" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Occupied"
+          }
+        }
+      }
+    },
+    "sensor.state.smoke.off" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear"
+          }
+        }
+      }
+    },
+    "sensor.state.smoke.on" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Smoke"
+          }
+        }
+      }
+    },
+    "sensor.type.carbon_dioxide" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Carbon Dioxide"
+          }
+        }
+      }
+    },
+    "sensor.type.carbon_monoxide" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Carbon Monoxide"
+          }
+        }
+      }
+    },
+    "sensor.type.contact" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Contact"
+          }
+        }
+      }
+    },
+    "sensor.type.leak" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Leak"
+          }
+        }
+      }
+    },
+    "sensor.type.motion" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Motion"
+          }
+        }
+      }
+    },
+    "sensor.type.occupancy" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Occupancy"
+          }
+        }
+      }
+    },
+    "sensor.type.smoke" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Smoke"
+          }
+        }
+      }
+    },
     "settings.about.description" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -9582,6 +10616,160 @@
         }
       }
     },
+    "settings.advanced.sensor_summary" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temperatur und Luftfeuchtigkeit zusammenfassen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Summarise temperature and humidity"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resumir temperatura y humedad"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Résumer température et humidité"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riassumi temperatura e umidità"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "温度と湿度をまとめて表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "온도 및 습도 요약"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Podsumuj temperaturę i wilgotność"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resumir temperatura e umidade"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сводка температуры и влажности"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "汇总温度和湿度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "彙總溫度和濕度"
+          }
+        }
+      }
+    },
+    "settings.advanced.sensor_summary_subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aus: zeigt jeden Sensor einzeln."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "When off, shows each sensor individually."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si está desactivado, muestra cada sensor individualmente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactivé, affiche chaque capteur individuellement."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se disattivo, mostra ogni sensore singolarmente."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフの場合、各センサーを個別に表示します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "끄면 각 센서를 개별적으로 표시합니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gdy wyłączone, pokazuje każdy czujnik osobno."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando desativado, mostra cada sensor individualmente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Когда выключено, показывает каждый датчик отдельно."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭时，单独显示每个传感器。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉時，個別顯示每個感測器。"
+          }
+        }
+      }
+    },
     "settings.advanced.title" : {
       "extractionState" : "extracted_with_value",
       "localizations" : {
@@ -9659,6 +10847,325 @@
         }
       }
     },
+    "settings.automations.add_button" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add Automation"
+          }
+        }
+      }
+    },
+    "settings.automations.delete_alert.message" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This automation will be removed."
+          }
+        }
+      }
+    },
+    "settings.automations.delete_alert.title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete \"%@\"?"
+          }
+        }
+      }
+    },
+    "settings.automations.description" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Automations watch a HomeKit accessory and, when it holds a state for a duration, set a virtual sensor (re-pulsing it) - so Apple Home can automate on conditions HomeKit can't compute itself, like \"open for 15 minutes\"."
+          }
+        }
+      }
+    },
+    "settings.automations.device.no_sensors" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No virtual sensors"
+          }
+        }
+      }
+    },
+    "settings.automations.empty" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No automations yet."
+          }
+        }
+      }
+    },
+    "settings.automations.form.action_note" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sets %1$@ to %2$@ while the trigger holds, then back to %3$@ when it clears."
+          }
+        }
+      }
+    },
+    "settings.automations.form.cancel_button" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "settings.automations.form.duration_note" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "0 = fire immediately. Time-of-day and presence conditions stay in Apple Home."
+          }
+        }
+      }
+    },
+    "settings.automations.form.edit_title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit automation"
+          }
+        }
+      }
+    },
+    "settings.automations.form.for_label" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "FOR"
+          }
+        }
+      }
+    },
+    "settings.automations.form.name_placeholder" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Name (e.g. Front Door left open)"
+          }
+        }
+      }
+    },
+    "settings.automations.form.new_title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New automation"
+          }
+        }
+      }
+    },
+    "settings.automations.form.repulse_every" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "every"
+          }
+        }
+      }
+    },
+    "settings.automations.form.repulse_label" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Re-pulse"
+          }
+        }
+      }
+    },
+    "settings.automations.form.repulse_note" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apple Home automations fire on a change, not a held state. Re-pulse re-fires the sensor on this interval while it's active, so a time- or presence-gated automation can still catch it."
+          }
+        }
+      }
+    },
+    "settings.automations.form.save_button" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save"
+          }
+        }
+      }
+    },
+    "settings.automations.form.then_label" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "THEN set a virtual sensor"
+          }
+        }
+      }
+    },
+    "settings.automations.form.when_label" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WHEN"
+          }
+        }
+      }
+    },
+    "settings.automations.status.active" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Active"
+          }
+        }
+      }
+    },
+    "settings.automations.status.disabled" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disabled"
+          }
+        }
+      }
+    },
+    "settings.automations.status.idle" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Idle"
+          }
+        }
+      }
+    },
+    "settings.automations.status.sensor_deleted" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor deleted"
+          }
+        }
+      }
+    },
+    "settings.automations.status.waiting" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Waiting"
+          }
+        }
+      }
+    },
+    "settings.automations.status.waiting_countdown" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Waiting %llds"
+          }
+        }
+      }
+    },
+    "settings.automations.summary.duration_minutes" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " for %lldm"
+          }
+        }
+      }
+    },
+    "settings.automations.summary.duration_seconds" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : " for %llds"
+          }
+        }
+      }
+    },
+    "settings.automations.summary.format" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@%3$@ -> %4$@"
+          }
+        }
+      }
+    },
+    "settings.automations.summary.missing_sensor" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "(missing sensor)"
+          }
+        }
+      }
+    },
     "settings.automations.title" : {
       "extractionState" : "extracted_with_value",
       "localizations" : {
@@ -9666,6 +11173,72 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Automations"
+          }
+        }
+      }
+    },
+    "settings.automations.trigger.no_sensors" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No sensors found"
+          }
+        }
+      }
+    },
+    "settings.automations.unit.minutes" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minutes"
+          }
+        }
+      }
+    },
+    "settings.automations.unit.seconds" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Seconds"
+          }
+        }
+      }
+    },
+    "settings.automations.validation.name_required" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Name is required."
+          }
+        }
+      }
+    },
+    "settings.automations.validation.no_device" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose a virtual sensor to drive."
+          }
+        }
+      }
+    },
+    "settings.automations.validation.no_trigger" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose a trigger."
           }
         }
       }
@@ -13707,6 +15280,402 @@
         }
       }
     },
+    "settings.homekit_bridge.add_device_button" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add Device"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.delete_alert.message" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This virtual sensor will be removed from Apple Home."
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.delete_alert.title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete \"%@\"?"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.delete_alert.used_by" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This sensor is used by %1$lld automation%2$@:\n%3$@\n\nDeleting it will break %4$@."
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.description" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Publish virtual sensors to Apple Home over HomeKit. Rooms are assigned in Apple Home after pairing."
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.devices_empty" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No virtual devices yet."
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.devices_header" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Virtual devices"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.enable_toggle" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable HomeKit Bridge"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.form.cancel_button" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.form.critical_note" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apple Home can raise critical alerts for %@ sensors."
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.form.edit_title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit device"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.form.error.name_required" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Name is required."
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.form.name_placeholder" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Name (e.g. Front Door)"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.form.new_title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New device"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.form.room_note" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The room is chosen in the Apple Home app after pairing."
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.form.save_button" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Save"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.info.accessibility" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "How to pair"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.info.tooltip" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "How to add this bridge to Apple Home"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.instructions.step1" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "1. Add a device and enable the bridge."
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.instructions.step2" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "2. In the Home app: Add Accessory, then More options."
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.instructions.step3" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "3. Pick “Itsyhome Bridge” and enter the setup code."
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.instructions.step4" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "4. Assign each device to a room in the Home app."
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.instructions.title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add to Apple Home"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.reset_alert.cancel_button" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.reset_alert.confirm_button" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reset"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.reset_alert.message" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This unpairs the bridge and generates a new setup code. Remove \"Itsyhome Bridge\" from the Apple Home app, then add it again with the new code."
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.reset_alert.title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reset HomeKit pairing?"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.reset_pairing_button" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reset Pairing"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.role.door" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Door"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.role.generic" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Generic"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.role.window" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Window"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.setup_code_label" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Setup code:"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.status_label" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Status:"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.status.error" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error: %@"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.status.running" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Running"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.status.stopped" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stopped"
+          }
+        }
+      }
+    },
     "settings.homekit_bridge.title" : {
       "extractionState" : "extracted_with_value",
       "localizations" : {
@@ -13714,6 +15683,17 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "HomeKit Bridge"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.toggle_state.tooltip" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Toggle state"
           }
         }
       }
@@ -16783,930 +18763,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "恢復預設"
-          }
-        }
-      }
-    },
-    "device.sensor.motion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bewegung"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Motion"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Movimiento"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mouvement"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Movimento"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "動き"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "움직임"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruch"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Movimento"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Движение"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有移动"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有移動"
-          }
-        }
-      }
-    },
-    "device.sensor.occupied" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Belegt"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Occupied"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ocupado"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Occupé"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Occupato"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在室"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "재실"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zajęte"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ocupado"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Занято"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有人"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有人"
-          }
-        }
-      }
-    },
-    "device.sensor.leak" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leck"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Leak"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fuga"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fuite"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Perdita"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "漏水"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "누수"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wyciek"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vazamento"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Протечка"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "漏水"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "漏水"
-          }
-        }
-      }
-    },
-    "device.sensor.dry" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trocken"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dry"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seco"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sec"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asciutto"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "乾燥"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "건조"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sucho"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seco"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сухо"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "干燥"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "乾燥"
-          }
-        }
-      }
-    },
-    "device.sensor.smoke" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rauch"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Smoke"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Humo"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fumée"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fumo"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "煙"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "연기"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dym"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fumaça"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Дым"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "烟雾"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "煙霧"
-          }
-        }
-      }
-    },
-    "device.sensor.co" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "CO"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO"
-          }
-        }
-      }
-    },
-    "device.sensor.co2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO2"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "CO2"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO2"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO2"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO2"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO2"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO2"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO2"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO2"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO2"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO2"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CO2"
-          }
-        }
-      }
-    },
-    "device.sensor.clear" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frei"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Normal"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Normal"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Normale"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正常"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "정상"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Czysto"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Normal"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Чисто"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正常"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正常"
-          }
-        }
-      }
-    },
-    "settings.advanced.sensor_summary" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Temperatur und Luftfeuchtigkeit zusammenfassen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Summarise temperature and humidity"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resumir temperatura y humedad"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Résumer température et humidité"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Riassumi temperatura e umidità"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "温度と湿度をまとめて表示"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "온도 및 습도 요약"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Podsumuj temperaturę i wilgotność"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resumir temperatura e umidade"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сводка температуры и влажности"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "汇总温度和湿度"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "彙總溫度和濕度"
-          }
-        }
-      }
-    },
-    "settings.advanced.sensor_summary_subtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aus: zeigt jeden Sensor einzeln."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "When off, shows each sensor individually."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si está desactivado, muestra cada sensor individualmente."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Désactivé, affiche chaque capteur individuellement."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se disattivo, mostra ogni sensore singolarmente."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オフの場合、各センサーを個別に表示します。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "끄면 각 센서를 개별적으로 표시합니다."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gdy wyłączone, pokazuje każdy czujnik osobno."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quando desativado, mostra cada sensor individualmente."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Когда выключено, показывает каждый датчик отдельно."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭时，单独显示每个传感器。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "關閉時，個別顯示每個感測器。"
-          }
-        }
-      }
-    },
-    "device.sensor.on" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "An"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "On"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activado"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activé"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attivo"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オン"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "켜짐"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wł."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ligado"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Вкл."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "开"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開"
-          }
-        }
-      }
-    },
-    "device.sensor.off" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aus"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Off"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desactivado"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Désactivé"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inattivo"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オフ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "꺼짐"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wył."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desligado"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выкл."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "關"
           }
         }
       }

--- a/macOSBridge/Resources/Localizable.xcstrings
+++ b/macOSBridge/Resources/Localizable.xcstrings
@@ -9659,6 +9659,17 @@
         }
       }
     },
+    "settings.automations.title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Automations"
+          }
+        }
+      }
+    },
     "settings.cameras.add_accessory" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -13692,6 +13703,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "家庭"
+          }
+        }
+      }
+    },
+    "settings.homekit_bridge.title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "HomeKit Bridge"
           }
         }
       }

--- a/macOSBridge/Settings/PreferencesManager+VirtualBridge.swift
+++ b/macOSBridge/Settings/PreferencesManager+VirtualBridge.swift
@@ -1,0 +1,36 @@
+//
+//  PreferencesManager+VirtualBridge.swift
+//  macOSBridge
+//
+//  Settings for the virtual HomeKit bridge: the master enable flag and the
+//  persisted setup code shown to the user for pairing.
+//
+import Foundation
+
+extension PreferencesManager {
+    private static let virtualBridgeEnabledKey = "virtualBridgeEnabled"
+    private static let virtualBridgeSetupCodeKey = "virtualBridgeSetupCode"
+
+    var virtualBridgeEnabled: Bool {
+        get { defaults.bool(forKey: Self.virtualBridgeEnabledKey) }
+        set { defaults.set(newValue, forKey: Self.virtualBridgeEnabledKey); postNotification() }
+    }
+
+    /// Stable HomeKit setup code in XXX-XX-XXX form, generated once and persisted.
+    var virtualBridgeSetupCode: String {
+        if let existing = defaults.string(forKey: Self.virtualBridgeSetupCodeKey), !existing.isEmpty {
+            return existing
+        }
+        let digits = (0..<8).map { _ in String(Int.random(in: 0...9)) }.joined()
+        let code = "\(digits.prefix(3))-\(digits.dropFirst(3).prefix(2))-\(digits.suffix(3))"
+        defaults.set(code, forKey: Self.virtualBridgeSetupCodeKey)
+        return code
+    }
+
+    /// Clear the stored setup code so a fresh one is generated on next access
+    /// (used by the bridge's full reset).
+    func resetVirtualBridgeSetupCode() {
+        defaults.removeObject(forKey: Self.virtualBridgeSetupCodeKey)
+        postNotification()
+    }
+}

--- a/macOSBridge/Settings/Sections/AutomationsSection.swift
+++ b/macOSBridge/Settings/Sections/AutomationsSection.swift
@@ -1,0 +1,549 @@
+//
+//  AutomationsSection.swift
+//  macOSBridge
+//
+//  Settings pane for automations: a list of automations each showing a live
+//  status (idle / waiting / active), with an inline WHEN / FOR / THEN builder
+//  that replaces the list. v1 builds "WHEN <accessory> reaches a state FOR
+//  <duration> THEN set a virtual sensor (re-pulsing it)". Mirrors the
+//  HomeKitBridgeSection idiom. The engine runs whenever Pro is active; each
+//  automation has its own enabled toggle (no master switch).
+//
+import AppKit
+
+class AutomationsSection: SettingsCard {
+
+    private var automationsHeader: NSView!
+    private let automationsStack = NSStackView()
+
+    // Inline builder
+    private let formContainer = NSView()
+    private var formTitleLabel: NSTextField!
+    private let nameField = NSTextField()
+    private let triggerPopUp = NSPopUpButton()
+    private let statePopUp = NSPopUpButton()
+    private let durationField = NSTextField()
+    private let durationUnitPopUp = NSPopUpButton()
+    private let devicePopUp = NSPopUpButton()
+    private var actionNote: NSTextField!
+    private let rePulseSwitch = NSSwitch()
+    private let rePulseField = NSTextField()
+    private let rePulseUnitPopUp = NSPopUpButton()
+    private var errorLabel: NSTextField!
+    private var editingAutomationId: UUID?
+
+    private var menuData: MenuData?
+    private var triggerOptions: [TriggerOption] = []
+    private var deviceOptions: [VirtualDevice] = []
+
+    private var automationStatusLabels: [UUID: NSTextField] = [:]
+    private var statusTimer: Timer?
+
+    private struct TriggerOption {
+        let accessoryName: String
+        let characteristicId: UUID
+        let label: String        // sensor type display, e.g. "Contact"
+        let title: String        // "Front Door - Contact"
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupContent()
+        observeNotifications()
+        statusTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            self?.updateStatuses()
+        }
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+    deinit { NotificationCenter.default.removeObserver(self); statusTimer?.invalidate() }
+
+    func configure(with data: MenuData) {
+        menuData = data
+        rebuildTriggerOptions()
+        rebuildAutomationsList()
+    }
+
+    // MARK: - Layout
+
+    private func setupContent() {
+        if !ProStatusCache.shared.isPro {
+            stackView.addArrangedSubview(Self.createProBanner())
+            stackView.addArrangedSubview(createSpacer(height: 8))
+        }
+
+        let desc = wrappingLabel(
+            "Automations watch a HomeKit accessory and, when it holds a state for a duration, set a virtual sensor (re-pulsing it) - so Apple Home can automate on conditions HomeKit can't compute itself, like \"open for 15 minutes\".")
+        stackView.addArrangedSubview(desc)
+        stackView.addArrangedSubview(createSpacer(height: 12))
+
+        automationsHeader = createAutomationsHeader()
+        stackView.addArrangedSubview(automationsHeader)
+        automationsHeader.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+
+        automationsStack.orientation = .vertical
+        automationsStack.spacing = 6
+        automationsStack.alignment = .leading
+        automationsStack.translatesAutoresizingMaskIntoConstraints = false
+        stackView.addArrangedSubview(automationsStack)
+        automationsStack.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+
+        setupForm()
+        stackView.addArrangedSubview(formContainer)
+        formContainer.isHidden = true
+        formContainer.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+
+        rebuildAutomationsList()
+    }
+
+    private func createAutomationsHeader() -> NSView {
+        let row = NSStackView()
+        row.orientation = .horizontal; row.spacing = 8; row.alignment = .centerY
+        row.translatesAutoresizingMaskIntoConstraints = false
+        row.addArrangedSubview(createLabel("Automations", style: .sectionHeader))
+        row.addArrangedSubview(NSView())
+        let add = NSButton(title: "Add Automation", target: self, action: #selector(showAddForm))
+        add.bezelStyle = .rounded; add.controlSize = .small
+        row.addArrangedSubview(add)
+        return row
+    }
+
+    // MARK: - Builder form
+
+    private func setupForm() {
+        let panel = NSStackView()
+        panel.orientation = .vertical; panel.spacing = 8; panel.alignment = .leading
+        panel.translatesAutoresizingMaskIntoConstraints = false
+
+        let sep = createSeparator()
+        panel.addArrangedSubview(sep)
+        sep.widthAnchor.constraint(equalTo: panel.widthAnchor).isActive = true
+
+        formTitleLabel = createLabel("New automation", style: .sectionHeader)
+        panel.addArrangedSubview(formTitleLabel)
+
+        nameField.placeholderString = "Name (e.g. Front Door left open)"
+        nameField.controlSize = .regular
+        panel.addArrangedSubview(labeledRow("Name", nameField))
+
+        // WHEN
+        panel.addArrangedSubview(createLabel("WHEN", style: .caption))
+        triggerPopUp.controlSize = .regular
+        triggerPopUp.target = self
+        triggerPopUp.action = #selector(triggerChanged)
+        panel.addArrangedSubview(labeledRow("Accessory", triggerPopUp))
+        statePopUp.controlSize = .regular
+        panel.addArrangedSubview(labeledRow("Is", statePopUp))
+
+        // FOR
+        panel.addArrangedSubview(createLabel("FOR", style: .caption))
+        durationField.placeholderString = "0"
+        durationField.controlSize = .regular
+        durationField.translatesAutoresizingMaskIntoConstraints = false
+        durationField.widthAnchor.constraint(equalToConstant: 60).isActive = true
+        durationUnitPopUp.addItems(withTitles: ["Seconds", "Minutes"])
+        durationUnitPopUp.selectItem(at: 1)
+        durationUnitPopUp.controlSize = .regular
+        panel.addArrangedSubview(fieldUnitRow("Duration", durationField, durationUnitPopUp))
+        let durNote = wrappingLabel("0 = fire immediately. Time-of-day and presence conditions stay in Apple Home.")
+        durNote.textColor = .tertiaryLabelColor
+        panel.addArrangedSubview(durNote)
+
+        // THEN
+        panel.addArrangedSubview(createLabel("THEN set a virtual sensor", style: .caption))
+        devicePopUp.controlSize = .regular
+        devicePopUp.target = self
+        devicePopUp.action = #selector(deviceChanged)
+        panel.addArrangedSubview(labeledRow("Sensor", devicePopUp))
+        actionNote = wrappingLabel("")
+        actionNote.textColor = .secondaryLabelColor
+        panel.addArrangedSubview(actionNote)
+
+        // Re-pulse
+        rePulseSwitch.controlSize = .mini
+        rePulseSwitch.state = .on
+        rePulseField.stringValue = "5"
+        rePulseField.controlSize = .regular
+        rePulseField.translatesAutoresizingMaskIntoConstraints = false
+        rePulseField.widthAnchor.constraint(equalToConstant: 60).isActive = true
+        rePulseUnitPopUp.addItems(withTitles: ["Seconds", "Minutes"])
+        rePulseUnitPopUp.selectItem(at: 1)
+        rePulseUnitPopUp.controlSize = .regular
+        let pulseRow = NSStackView()
+        pulseRow.orientation = .horizontal; pulseRow.spacing = 8; pulseRow.alignment = .centerY
+        pulseRow.translatesAutoresizingMaskIntoConstraints = false
+        let pulseLabel = createLabel("Re-pulse", style: .body)
+        pulseLabel.translatesAutoresizingMaskIntoConstraints = false
+        pulseLabel.widthAnchor.constraint(equalToConstant: 110).isActive = true
+        pulseRow.addArrangedSubview(pulseLabel)
+        pulseRow.addArrangedSubview(rePulseSwitch)
+        pulseRow.addArrangedSubview(createLabel("every", style: .caption))
+        pulseRow.addArrangedSubview(rePulseField)
+        pulseRow.addArrangedSubview(rePulseUnitPopUp)
+        panel.addArrangedSubview(pulseRow)
+        let pulseNote = wrappingLabel("Apple Home automations fire on a change, not a held state. Re-pulse re-fires the sensor on this interval while it's active, so a time- or presence-gated automation can still catch it.")
+        pulseNote.textColor = .tertiaryLabelColor
+        panel.addArrangedSubview(pulseNote)
+
+        errorLabel = createLabel("", style: .caption)
+        errorLabel.textColor = .systemRed
+        panel.addArrangedSubview(errorLabel)
+
+        let buttons = NSStackView()
+        buttons.orientation = .horizontal; buttons.spacing = 8; buttons.alignment = .centerY
+        buttons.translatesAutoresizingMaskIntoConstraints = false
+        buttons.addArrangedSubview(NSView())
+        let cancel = NSButton(title: "Cancel", target: self, action: #selector(cancelForm))
+        cancel.bezelStyle = .rounded; cancel.controlSize = .small; cancel.keyEquivalent = "\u{1b}"
+        buttons.addArrangedSubview(cancel)
+        let save = NSButton(title: "Save", target: self, action: #selector(saveAutomation))
+        save.bezelStyle = .rounded; save.controlSize = .small; save.keyEquivalent = "\r"
+        buttons.addArrangedSubview(save)
+        panel.addArrangedSubview(buttons)
+        buttons.widthAnchor.constraint(equalTo: panel.widthAnchor).isActive = true
+
+        formContainer.addSubview(panel)
+        NSLayoutConstraint.activate([
+            panel.topAnchor.constraint(equalTo: formContainer.topAnchor),
+            panel.leadingAnchor.constraint(equalTo: formContainer.leadingAnchor),
+            panel.trailingAnchor.constraint(equalTo: formContainer.trailingAnchor),
+            panel.bottomAnchor.constraint(equalTo: formContainer.bottomAnchor)
+        ])
+    }
+
+    private func labeledRow(_ label: String, _ control: NSView) -> NSView {
+        let row = NSStackView()
+        row.orientation = .horizontal; row.spacing = 8; row.alignment = .centerY
+        row.translatesAutoresizingMaskIntoConstraints = false
+        let l = createLabel(label, style: .body)
+        l.translatesAutoresizingMaskIntoConstraints = false
+        l.widthAnchor.constraint(equalToConstant: 110).isActive = true
+        control.translatesAutoresizingMaskIntoConstraints = false
+        row.addArrangedSubview(l)
+        row.addArrangedSubview(control)
+        return row
+    }
+
+    private func fieldUnitRow(_ label: String, _ field: NSTextField, _ unit: NSPopUpButton) -> NSView {
+        let row = NSStackView()
+        row.orientation = .horizontal; row.spacing = 8; row.alignment = .centerY
+        row.translatesAutoresizingMaskIntoConstraints = false
+        let l = createLabel(label, style: .body)
+        l.translatesAutoresizingMaskIntoConstraints = false
+        l.widthAnchor.constraint(equalToConstant: 110).isActive = true
+        row.addArrangedSubview(l)
+        row.addArrangedSubview(field)
+        row.addArrangedSubview(unit)
+        return row
+    }
+
+    private func setFormVisible(_ visible: Bool) {
+        automationsHeader.isHidden = visible
+        automationsStack.isHidden = visible
+        formContainer.isHidden = !visible
+    }
+
+    // MARK: - Options
+
+    private func rebuildTriggerOptions() {
+        var opts: [TriggerOption] = []
+        for acc in menuData?.accessories ?? [] {
+            for svc in acc.services {
+                let pairs: [(String?, String)] = [
+                    (svc.contactSensorStateId, "Contact"),
+                    (svc.motionDetectedId, "Motion"),
+                    (svc.occupancyDetectedId, "Occupancy"),
+                    (svc.leakDetectedId, "Leak"),
+                    (svc.smokeDetectedId, "Smoke"),
+                    (svc.carbonMonoxideDetectedId, "Carbon Monoxide"),
+                    (svc.carbonDioxideDetectedId, "Carbon Dioxide")
+                ]
+                for (idStr, label) in pairs {
+                    if let idStr, let id = UUID(uuidString: idStr) {
+                        opts.append(TriggerOption(accessoryName: acc.name, characteristicId: id,
+                            label: label, title: "\(acc.name) - \(label)"))
+                    }
+                }
+            }
+        }
+        triggerOptions = opts
+        triggerPopUp.removeAllItems()
+        triggerPopUp.addItems(withTitles: opts.isEmpty ? ["No sensors found"] : opts.map(\.title))
+        triggerChanged()
+    }
+
+    private func rebuildDeviceOptions() {
+        deviceOptions = VirtualDeviceStore.shared.devices
+        devicePopUp.removeAllItems()
+        devicePopUp.addItems(withTitles: deviceOptions.isEmpty ? ["No virtual sensors"] : deviceOptions.map(\.name))
+        deviceChanged()
+    }
+
+    private func words(forLabel label: String) -> (on: String, off: String) {
+        switch label {
+        case "Contact": return ("Open", "Closed")
+        case "Motion": return ("Motion", "Clear")
+        case "Occupancy": return ("Occupied", "Clear")
+        case "Leak": return ("Leak", "Dry")
+        case "Smoke": return ("Smoke", "Clear")
+        case "Carbon Monoxide": return ("CO", "Clear")
+        case "Carbon Dioxide": return ("CO2", "Clear")
+        default: return ("On", "Off")
+        }
+    }
+
+    @objc private func triggerChanged() {
+        let idx = triggerPopUp.indexOfSelectedItem
+        guard idx >= 0, idx < triggerOptions.count else { statePopUp.removeAllItems(); return }
+        let w = words(forLabel: triggerOptions[idx].label)
+        statePopUp.removeAllItems()
+        statePopUp.addItems(withTitles: [w.on, w.off])  // index 0 = active (value 1)
+    }
+
+    @objc private func deviceChanged() {
+        let idx = devicePopUp.indexOfSelectedItem
+        guard idx >= 0, idx < deviceOptions.count else { actionNote.stringValue = ""; return }
+        let d = deviceOptions[idx]
+        actionNote.stringValue = "Sets \(d.name) to \(d.type.stateWord(on: true)) while the trigger holds, then back to \(d.type.stateWord(on: false)) when it clears."
+    }
+
+    // MARK: - Automations list
+
+    private func rebuildAutomationsList() {
+        automationStatusLabels.removeAll()
+        for v in automationsStack.arrangedSubviews { automationsStack.removeArrangedSubview(v); v.removeFromSuperview() }
+        let automations = AutomationStore.shared.automations
+        if automations.isEmpty {
+            automationsStack.addArrangedSubview(createLabel("No automations yet.", style: .caption))
+            return
+        }
+        for automation in automations {
+            let row = createAutomationRow(automation)
+            automationsStack.addArrangedSubview(row)
+            row.widthAnchor.constraint(equalTo: automationsStack.widthAnchor).isActive = true
+        }
+        updateStatuses()
+    }
+
+    private func createAutomationRow(_ automation: Automation) -> NSView {
+        let row = NSStackView()
+        row.orientation = .horizontal; row.spacing = 8; row.alignment = .centerY
+        row.translatesAutoresizingMaskIntoConstraints = false
+
+        let textCol = NSStackView()
+        textCol.orientation = .vertical; textCol.spacing = 1; textCol.alignment = .leading
+        textCol.addArrangedSubview(createLabel(automation.name, style: .body))
+        let summary = createLabel(automationSummary(automation), style: .caption)
+        summary.textColor = automationTargetMissing(automation) ? .systemRed : .secondaryLabelColor
+        textCol.addArrangedSubview(summary)
+        row.addArrangedSubview(textCol)
+
+        row.addArrangedSubview(NSView())
+
+        let status = createLabel("", style: .caption)
+        automationStatusLabels[automation.id] = status
+        row.addArrangedSubview(status)
+
+        let toggle = NSSwitch()
+        toggle.controlSize = .mini
+        toggle.state = automation.enabled ? .on : .off
+        toggle.target = self
+        toggle.action = #selector(automationEnabledChanged(_:))
+        toggle.identifier = NSUserInterfaceItemIdentifier(automation.id.uuidString)
+        row.addArrangedSubview(toggle)
+
+        row.addArrangedSubview(iconButton("pencil", action: #selector(editAutomation(_:)), id: automation.id))
+        row.addArrangedSubview(iconButton("xmark.circle.fill", action: #selector(removeAutomation(_:)), id: automation.id))
+
+        row.heightAnchor.constraint(greaterThanOrEqualToConstant: 32).isActive = true
+        return row
+    }
+
+    private func automationSummary(_ automation: Automation) -> String {
+        guard case .accessoryState(let t) = automation.trigger,
+              case .setVirtualSensor(let a)? = automation.actions.first else { return automation.name }
+        let w = words(forLabel: t.characteristicLabel)
+        let stateWord = t.value != 0 ? w.on : w.off
+        let dur: String
+        if let s = automation.durationSeconds, s > 0 {
+            dur = s % 60 == 0 ? " for \(s / 60)m" : " for \(s)s"
+        } else { dur = "" }
+        let target = VirtualDeviceStore.shared.device(id: a.deviceId)?.name ?? "(missing sensor)"
+        return "\(t.accessoryName) \(stateWord)\(dur) -> \(target)"
+    }
+
+    private func iconButton(_ symbol: String, action: Selector, id: UUID) -> NSButton {
+        let b = NSButton(title: "", target: self, action: action)
+        b.image = NSImage(systemSymbolName: symbol, accessibilityDescription: nil)
+        b.imagePosition = .imageOnly
+        b.isBordered = false
+        b.contentTintColor = .secondaryLabelColor
+        b.translatesAutoresizingMaskIntoConstraints = false
+        b.widthAnchor.constraint(equalToConstant: 20).isActive = true
+        b.heightAnchor.constraint(equalToConstant: 20).isActive = true
+        b.identifier = NSUserInterfaceItemIdentifier(id.uuidString)
+        return b
+    }
+
+    // MARK: - Live status
+
+    private func updateStatuses() {
+        for (id, label) in automationStatusLabels {
+            let (text, color) = statusText(id)
+            label.stringValue = text
+            label.textColor = color
+        }
+    }
+
+    private func statusText(_ id: UUID) -> (String, NSColor) {
+        guard let automation = AutomationStore.shared.automation(id: id) else { return ("", .secondaryLabelColor) }
+        if automationTargetMissing(automation) { return ("Sensor deleted", .systemRed) }
+        if !automation.enabled { return ("Disabled", .tertiaryLabelColor) }
+        switch AutomationEngine.shared.runtimeState(automationId: id) {
+        case .active:
+            return ("Active", .systemGreen)
+        case .armed:
+            if let r = AutomationEngine.shared.armedRemaining(automationId: id) { return ("Waiting \(r)s", .systemOrange) }
+            return ("Waiting", .systemOrange)
+        case .idle:
+            return ("Idle", .secondaryLabelColor)
+        }
+    }
+
+    /// True if the automation's target virtual sensor no longer exists.
+    private func automationTargetMissing(_ automation: Automation) -> Bool {
+        guard case .setVirtualSensor(let a)? = automation.actions.first else { return false }
+        return VirtualDeviceStore.shared.device(id: a.deviceId) == nil
+    }
+
+    // MARK: - Actions
+
+    @objc private func showAddForm() {
+        editingAutomationId = nil
+        formTitleLabel.stringValue = "New automation"
+        nameField.stringValue = ""
+        rebuildTriggerOptions()
+        rebuildDeviceOptions()
+        durationField.stringValue = ""
+        durationUnitPopUp.selectItem(at: 1)
+        rePulseSwitch.state = .on
+        rePulseField.stringValue = "5"
+        rePulseUnitPopUp.selectItem(at: 1)
+        errorLabel.stringValue = ""
+        setFormVisible(true)
+    }
+
+    private func showEditForm(_ automation: Automation) {
+        editingAutomationId = automation.id
+        formTitleLabel.stringValue = "Edit automation"
+        nameField.stringValue = automation.name
+        rebuildTriggerOptions()
+        rebuildDeviceOptions()
+        if case .accessoryState(let t) = automation.trigger,
+           let idx = triggerOptions.firstIndex(where: { $0.characteristicId == t.characteristicId }) {
+            triggerPopUp.selectItem(at: idx)
+            triggerChanged()
+            statePopUp.selectItem(at: t.value != 0 ? 0 : 1)
+        }
+        if let s = automation.durationSeconds, s > 0 {
+            if s % 60 == 0 { durationField.stringValue = "\(s / 60)"; durationUnitPopUp.selectItem(at: 1) }
+            else { durationField.stringValue = "\(s)"; durationUnitPopUp.selectItem(at: 0) }
+        } else { durationField.stringValue = "" }
+        if case .setVirtualSensor(let a)? = automation.actions.first {
+            if let idx = deviceOptions.firstIndex(where: { $0.id == a.deviceId }) {
+                devicePopUp.selectItem(at: idx); deviceChanged()
+            }
+            rePulseSwitch.state = a.rePulse.enabled ? .on : .off
+            let i = a.rePulse.intervalSeconds
+            if i % 60 == 0 { rePulseField.stringValue = "\(i / 60)"; rePulseUnitPopUp.selectItem(at: 1) }
+            else { rePulseField.stringValue = "\(i)"; rePulseUnitPopUp.selectItem(at: 0) }
+        }
+        errorLabel.stringValue = ""
+        setFormVisible(true)
+    }
+
+    @objc private func cancelForm() { editingAutomationId = nil; setFormVisible(false) }
+
+    @objc private func saveAutomation() {
+        let durUnit = durationUnitPopUp.indexOfSelectedItem == 1 ? 60 : 1
+        let durationSeconds = max(0, Int(durationField.stringValue) ?? 0) * durUnit
+        let triggerIdx = triggerPopUp.indexOfSelectedItem
+        let trigger: AccessoryStateTrigger? = (triggerIdx >= 0 && triggerIdx < triggerOptions.count) ? {
+            let o = triggerOptions[triggerIdx]
+            return AccessoryStateTrigger(characteristicId: o.characteristicId, accessoryName: o.accessoryName,
+                characteristicLabel: o.label, comparator: .equal, value: statePopUp.indexOfSelectedItem == 0 ? 1 : 0)
+        }() : nil
+        let deviceIdx = devicePopUp.indexOfSelectedItem
+        let deviceId: UUID? = (deviceIdx >= 0 && deviceIdx < deviceOptions.count) ? deviceOptions[deviceIdx].id : nil
+        let pulseUnit = rePulseUnitPopUp.indexOfSelectedItem == 1 ? 60 : 1
+        let pulseInterval = max(1, (Int(rePulseField.stringValue) ?? 5) * pulseUnit)
+
+        let draft = AutomationDraft(id: editingAutomationId, name: nameField.stringValue, trigger: trigger,
+            durationSeconds: durationSeconds, actionDeviceId: deviceId,
+            rePulseEnabled: rePulseSwitch.state == .on, rePulseInterval: pulseInterval)
+
+        if let err = draft.validationError() { errorLabel.stringValue = err; return }
+        AutomationStore.shared.upsert(draft.build())
+        AutomationEngine.shared.reload()
+        editingAutomationId = nil
+        setFormVisible(false)
+        rebuildAutomationsList()
+    }
+
+    @objc private func automationEnabledChanged(_ sender: NSSwitch) {
+        guard let s = sender.identifier?.rawValue, let id = UUID(uuidString: s) else { return }
+        AutomationStore.shared.setEnabled(sender.state == .on, id: id)
+        AutomationEngine.shared.reload()
+    }
+
+    @objc private func editAutomation(_ sender: NSButton) {
+        guard let s = sender.identifier?.rawValue, let id = UUID(uuidString: s),
+              let automation = AutomationStore.shared.automation(id: id) else { return }
+        showEditForm(automation)
+    }
+
+    @objc private func removeAutomation(_ sender: NSButton) {
+        guard let s = sender.identifier?.rawValue, let id = UUID(uuidString: s),
+              let automation = AutomationStore.shared.automation(id: id) else { return }
+        let alert = NSAlert()
+        alert.messageText = "Delete \"\(automation.name)\"?"
+        alert.informativeText = "This automation will be removed."
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        AutomationStore.shared.remove(id: id)
+        AutomationEngine.shared.reload()
+        rebuildAutomationsList()
+    }
+
+    // MARK: - Observers
+
+    private func observeNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(storeChanged),
+            name: AutomationStore.didChangeNotification, object: nil)
+        // Also rebuild when virtual devices change, so a deleted sensor a automation
+        // depends on shows as unresolved immediately (no restart).
+        NotificationCenter.default.addObserver(self, selector: #selector(storeChanged),
+            name: VirtualDeviceStore.didChangeNotification, object: nil)
+    }
+    @objc private func storeChanged() {
+        DispatchQueue.main.async { [weak self] in self?.rebuildAutomationsList() }
+    }
+
+    // MARK: - Helpers
+
+    private func wrappingLabel(_ text: String) -> NSTextField {
+        let l = createLabel(text, style: .caption)
+        l.lineBreakMode = .byWordWrapping
+        l.maximumNumberOfLines = 0
+        l.preferredMaxLayoutWidth = 460
+        return l
+    }
+
+    private func createSpacer(height: CGFloat) -> NSView {
+        let s = NSView()
+        s.translatesAutoresizingMaskIntoConstraints = false
+        s.heightAnchor.constraint(equalToConstant: height).isActive = true
+        return s
+    }
+}

--- a/macOSBridge/Settings/Sections/AutomationsSection.swift
+++ b/macOSBridge/Settings/Sections/AutomationsSection.swift
@@ -73,7 +73,7 @@ class AutomationsSection: SettingsCard {
         }
 
         let desc = wrappingLabel(
-            "Automations watch a HomeKit accessory and, when it holds a state for a duration, set a virtual sensor (re-pulsing it) - so Apple Home can automate on conditions HomeKit can't compute itself, like \"open for 15 minutes\".")
+            String(localized: "settings.automations.description", defaultValue: "Automations watch a HomeKit accessory and, when it holds a state for a duration, set a virtual sensor (re-pulsing it) - so Apple Home can automate on conditions HomeKit can't compute itself, like \"open for 15 minutes\".", bundle: .macOSBridge))
         stackView.addArrangedSubview(desc)
         stackView.addArrangedSubview(createSpacer(height: 12))
 
@@ -100,9 +100,9 @@ class AutomationsSection: SettingsCard {
         let row = NSStackView()
         row.orientation = .horizontal; row.spacing = 8; row.alignment = .centerY
         row.translatesAutoresizingMaskIntoConstraints = false
-        row.addArrangedSubview(createLabel("Automations", style: .sectionHeader))
+        row.addArrangedSubview(createLabel(String(localized: "settings.automations.title", defaultValue: "Automations", bundle: .macOSBridge), style: .sectionHeader))
         row.addArrangedSubview(NSView())
-        let add = NSButton(title: "Add Automation", target: self, action: #selector(showAddForm))
+        let add = NSButton(title: String(localized: "settings.automations.add_button", defaultValue: "Add Automation", bundle: .macOSBridge), target: self, action: #selector(showAddForm))
         add.bezelStyle = .rounded; add.controlSize = .small
         row.addArrangedSubview(add)
         return row
@@ -119,15 +119,15 @@ class AutomationsSection: SettingsCard {
         panel.addArrangedSubview(sep)
         sep.widthAnchor.constraint(equalTo: panel.widthAnchor).isActive = true
 
-        formTitleLabel = createLabel("New automation", style: .sectionHeader)
+        formTitleLabel = createLabel(String(localized: "settings.automations.form.new_title", defaultValue: "New automation", bundle: .macOSBridge), style: .sectionHeader)
         panel.addArrangedSubview(formTitleLabel)
 
-        nameField.placeholderString = "Name (e.g. Front Door left open)"
+        nameField.placeholderString = String(localized: "settings.automations.form.name_placeholder", defaultValue: "Name (e.g. Front Door left open)", bundle: .macOSBridge)
         nameField.controlSize = .regular
         panel.addArrangedSubview(labeledRow("Name", nameField))
 
         // WHEN
-        panel.addArrangedSubview(createLabel("WHEN", style: .caption))
+        panel.addArrangedSubview(createLabel(String(localized: "settings.automations.form.when_label", defaultValue: "WHEN", bundle: .macOSBridge), style: .caption))
         triggerPopUp.controlSize = .regular
         triggerPopUp.target = self
         triggerPopUp.action = #selector(triggerChanged)
@@ -136,21 +136,24 @@ class AutomationsSection: SettingsCard {
         panel.addArrangedSubview(labeledRow("Is", statePopUp))
 
         // FOR
-        panel.addArrangedSubview(createLabel("FOR", style: .caption))
+        panel.addArrangedSubview(createLabel(String(localized: "settings.automations.form.for_label", defaultValue: "FOR", bundle: .macOSBridge), style: .caption))
         durationField.placeholderString = "0"
         durationField.controlSize = .regular
         durationField.translatesAutoresizingMaskIntoConstraints = false
         durationField.widthAnchor.constraint(equalToConstant: 60).isActive = true
-        durationUnitPopUp.addItems(withTitles: ["Seconds", "Minutes"])
+        durationUnitPopUp.addItems(withTitles: [
+            String(localized: "settings.automations.unit.seconds", defaultValue: "Seconds", bundle: .macOSBridge),
+            String(localized: "settings.automations.unit.minutes", defaultValue: "Minutes", bundle: .macOSBridge)
+        ])
         durationUnitPopUp.selectItem(at: 1)
         durationUnitPopUp.controlSize = .regular
         panel.addArrangedSubview(fieldUnitRow("Duration", durationField, durationUnitPopUp))
-        let durNote = wrappingLabel("0 = fire immediately. Time-of-day and presence conditions stay in Apple Home.")
+        let durNote = wrappingLabel(String(localized: "settings.automations.form.duration_note", defaultValue: "0 = fire immediately. Time-of-day and presence conditions stay in Apple Home.", bundle: .macOSBridge))
         durNote.textColor = .tertiaryLabelColor
         panel.addArrangedSubview(durNote)
 
         // THEN
-        panel.addArrangedSubview(createLabel("THEN set a virtual sensor", style: .caption))
+        panel.addArrangedSubview(createLabel(String(localized: "settings.automations.form.then_label", defaultValue: "THEN set a virtual sensor", bundle: .macOSBridge), style: .caption))
         devicePopUp.controlSize = .regular
         devicePopUp.target = self
         devicePopUp.action = #selector(deviceChanged)
@@ -166,22 +169,25 @@ class AutomationsSection: SettingsCard {
         rePulseField.controlSize = .regular
         rePulseField.translatesAutoresizingMaskIntoConstraints = false
         rePulseField.widthAnchor.constraint(equalToConstant: 60).isActive = true
-        rePulseUnitPopUp.addItems(withTitles: ["Seconds", "Minutes"])
+        rePulseUnitPopUp.addItems(withTitles: [
+            String(localized: "settings.automations.unit.seconds", defaultValue: "Seconds", bundle: .macOSBridge),
+            String(localized: "settings.automations.unit.minutes", defaultValue: "Minutes", bundle: .macOSBridge)
+        ])
         rePulseUnitPopUp.selectItem(at: 1)
         rePulseUnitPopUp.controlSize = .regular
         let pulseRow = NSStackView()
         pulseRow.orientation = .horizontal; pulseRow.spacing = 8; pulseRow.alignment = .centerY
         pulseRow.translatesAutoresizingMaskIntoConstraints = false
-        let pulseLabel = createLabel("Re-pulse", style: .body)
+        let pulseLabel = createLabel(String(localized: "settings.automations.form.repulse_label", defaultValue: "Re-pulse", bundle: .macOSBridge), style: .body)
         pulseLabel.translatesAutoresizingMaskIntoConstraints = false
         pulseLabel.widthAnchor.constraint(equalToConstant: 110).isActive = true
         pulseRow.addArrangedSubview(pulseLabel)
         pulseRow.addArrangedSubview(rePulseSwitch)
-        pulseRow.addArrangedSubview(createLabel("every", style: .caption))
+        pulseRow.addArrangedSubview(createLabel(String(localized: "settings.automations.form.repulse_every", defaultValue: "every", bundle: .macOSBridge), style: .caption))
         pulseRow.addArrangedSubview(rePulseField)
         pulseRow.addArrangedSubview(rePulseUnitPopUp)
         panel.addArrangedSubview(pulseRow)
-        let pulseNote = wrappingLabel("Apple Home automations fire on a change, not a held state. Re-pulse re-fires the sensor on this interval while it's active, so a time- or presence-gated automation can still catch it.")
+        let pulseNote = wrappingLabel(String(localized: "settings.automations.form.repulse_note", defaultValue: "Apple Home automations fire on a change, not a held state. Re-pulse re-fires the sensor on this interval while it's active, so a time- or presence-gated automation can still catch it.", bundle: .macOSBridge))
         pulseNote.textColor = .tertiaryLabelColor
         panel.addArrangedSubview(pulseNote)
 
@@ -193,10 +199,10 @@ class AutomationsSection: SettingsCard {
         buttons.orientation = .horizontal; buttons.spacing = 8; buttons.alignment = .centerY
         buttons.translatesAutoresizingMaskIntoConstraints = false
         buttons.addArrangedSubview(NSView())
-        let cancel = NSButton(title: "Cancel", target: self, action: #selector(cancelForm))
+        let cancel = NSButton(title: String(localized: "settings.automations.form.cancel_button", defaultValue: "Cancel", bundle: .macOSBridge), target: self, action: #selector(cancelForm))
         cancel.bezelStyle = .rounded; cancel.controlSize = .small; cancel.keyEquivalent = "\u{1b}"
         buttons.addArrangedSubview(cancel)
-        let save = NSButton(title: "Save", target: self, action: #selector(saveAutomation))
+        let save = NSButton(title: String(localized: "settings.automations.form.save_button", defaultValue: "Save", bundle: .macOSBridge), target: self, action: #selector(saveAutomation))
         save.bezelStyle = .rounded; save.controlSize = .small; save.keyEquivalent = "\r"
         buttons.addArrangedSubview(save)
         panel.addArrangedSubview(buttons)
@@ -260,36 +266,50 @@ class AutomationsSection: SettingsCard {
                 ]
                 for (idStr, label) in pairs {
                     if let idStr, let id = UUID(uuidString: idStr) {
+                        // `label` stays English (stored key); the shown title uses
+                        // the localized type name.
+                        let typeName = Self.sensorType(forTriggerLabel: label)?.displayName ?? label
                         opts.append(TriggerOption(accessoryName: acc.name, characteristicId: id,
-                            label: label, title: "\(acc.name) - \(label)"))
+                            label: label, title: "\(acc.name) - \(typeName)"))
                     }
                 }
             }
         }
         triggerOptions = opts
         triggerPopUp.removeAllItems()
-        triggerPopUp.addItems(withTitles: opts.isEmpty ? ["No sensors found"] : opts.map(\.title))
+        triggerPopUp.addItems(withTitles: opts.isEmpty ? [String(localized: "settings.automations.trigger.no_sensors", defaultValue: "No sensors found", bundle: .macOSBridge)] : opts.map(\.title))
         triggerChanged()
     }
 
     private func rebuildDeviceOptions() {
         deviceOptions = VirtualDeviceStore.shared.devices
         devicePopUp.removeAllItems()
-        devicePopUp.addItems(withTitles: deviceOptions.isEmpty ? ["No virtual sensors"] : deviceOptions.map(\.name))
+        devicePopUp.addItems(withTitles: deviceOptions.isEmpty ? [String(localized: "settings.automations.device.no_sensors", defaultValue: "No virtual sensors", bundle: .macOSBridge)] : deviceOptions.map(\.name))
         deviceChanged()
     }
 
-    private func words(forLabel label: String) -> (on: String, off: String) {
+    /// Maps a trigger option's stable English label to its sensor type. The
+    /// label is also stored as `Automation.characteristicLabel`, so it stays
+    /// English (a stable key); all display strings come from the type.
+    private static func sensorType(forTriggerLabel label: String) -> VirtualSensorType? {
         switch label {
-        case "Contact": return ("Open", "Closed")
-        case "Motion": return ("Motion", "Clear")
-        case "Occupancy": return ("Occupied", "Clear")
-        case "Leak": return ("Leak", "Dry")
-        case "Smoke": return ("Smoke", "Clear")
-        case "Carbon Monoxide": return ("CO", "Clear")
-        case "Carbon Dioxide": return ("CO2", "Clear")
-        default: return ("On", "Off")
+        case "Contact": return .contact
+        case "Motion": return .motion
+        case "Occupancy": return .occupancy
+        case "Leak": return .leak
+        case "Smoke": return .smoke
+        case "Carbon Monoxide": return .carbonMonoxide
+        case "Carbon Dioxide": return .carbonDioxide
+        default: return nil
         }
+    }
+
+    private func words(forLabel label: String) -> (on: String, off: String) {
+        guard let type = Self.sensorType(forTriggerLabel: label) else {
+            return (String(localized: "sensor.state.generic.on", defaultValue: "On", bundle: .macOSBridge),
+                    String(localized: "sensor.state.generic.off", defaultValue: "Off", bundle: .macOSBridge))
+        }
+        return (type.stateWord(on: true), type.stateWord(on: false))
     }
 
     @objc private func triggerChanged() {
@@ -304,7 +324,7 @@ class AutomationsSection: SettingsCard {
         let idx = devicePopUp.indexOfSelectedItem
         guard idx >= 0, idx < deviceOptions.count else { actionNote.stringValue = ""; return }
         let d = deviceOptions[idx]
-        actionNote.stringValue = "Sets \(d.name) to \(d.type.stateWord(on: true)) while the trigger holds, then back to \(d.type.stateWord(on: false)) when it clears."
+        actionNote.stringValue = String(localized: "settings.automations.form.action_note", defaultValue: "Sets \(d.name) to \(d.type.stateWord(on: true)) while the trigger holds, then back to \(d.type.stateWord(on: false)) when it clears.", bundle: .macOSBridge)
     }
 
     // MARK: - Automations list
@@ -314,7 +334,7 @@ class AutomationsSection: SettingsCard {
         for v in automationsStack.arrangedSubviews { automationsStack.removeArrangedSubview(v); v.removeFromSuperview() }
         let automations = AutomationStore.shared.automations
         if automations.isEmpty {
-            automationsStack.addArrangedSubview(createLabel("No automations yet.", style: .caption))
+            automationsStack.addArrangedSubview(createLabel(String(localized: "settings.automations.empty", defaultValue: "No automations yet.", bundle: .macOSBridge), style: .caption))
             return
         }
         for automation in automations {
@@ -366,10 +386,13 @@ class AutomationsSection: SettingsCard {
         let stateWord = t.value != 0 ? w.on : w.off
         let dur: String
         if let s = automation.durationSeconds, s > 0 {
-            dur = s % 60 == 0 ? " for \(s / 60)m" : " for \(s)s"
+            dur = s % 60 == 0
+                ? String(localized: "settings.automations.summary.duration_minutes", defaultValue: " for \(s / 60)m", bundle: .macOSBridge)
+                : String(localized: "settings.automations.summary.duration_seconds", defaultValue: " for \(s)s", bundle: .macOSBridge)
         } else { dur = "" }
-        let target = VirtualDeviceStore.shared.device(id: a.deviceId)?.name ?? "(missing sensor)"
-        return "\(t.accessoryName) \(stateWord)\(dur) -> \(target)"
+        let target = VirtualDeviceStore.shared.device(id: a.deviceId)?.name
+            ?? String(localized: "settings.automations.summary.missing_sensor", defaultValue: "(missing sensor)", bundle: .macOSBridge)
+        return String(localized: "settings.automations.summary.format", defaultValue: "\(t.accessoryName) \(stateWord)\(dur) -> \(target)", bundle: .macOSBridge)
     }
 
     private func iconButton(_ symbol: String, action: Selector, id: UUID) -> NSButton {
@@ -397,16 +420,16 @@ class AutomationsSection: SettingsCard {
 
     private func statusText(_ id: UUID) -> (String, NSColor) {
         guard let automation = AutomationStore.shared.automation(id: id) else { return ("", .secondaryLabelColor) }
-        if automationTargetMissing(automation) { return ("Sensor deleted", .systemRed) }
-        if !automation.enabled { return ("Disabled", .tertiaryLabelColor) }
+        if automationTargetMissing(automation) { return (String(localized: "settings.automations.status.sensor_deleted", defaultValue: "Sensor deleted", bundle: .macOSBridge), .systemRed) }
+        if !automation.enabled { return (String(localized: "settings.automations.status.disabled", defaultValue: "Disabled", bundle: .macOSBridge), .tertiaryLabelColor) }
         switch AutomationEngine.shared.runtimeState(automationId: id) {
         case .active:
-            return ("Active", .systemGreen)
+            return (String(localized: "settings.automations.status.active", defaultValue: "Active", bundle: .macOSBridge), .systemGreen)
         case .armed:
-            if let r = AutomationEngine.shared.armedRemaining(automationId: id) { return ("Waiting \(r)s", .systemOrange) }
-            return ("Waiting", .systemOrange)
+            if let r = AutomationEngine.shared.armedRemaining(automationId: id) { return (String(localized: "settings.automations.status.waiting_countdown", defaultValue: "Waiting \(r)s", bundle: .macOSBridge), .systemOrange) }
+            return (String(localized: "settings.automations.status.waiting", defaultValue: "Waiting", bundle: .macOSBridge), .systemOrange)
         case .idle:
-            return ("Idle", .secondaryLabelColor)
+            return (String(localized: "settings.automations.status.idle", defaultValue: "Idle", bundle: .macOSBridge), .secondaryLabelColor)
         }
     }
 
@@ -420,7 +443,7 @@ class AutomationsSection: SettingsCard {
 
     @objc private func showAddForm() {
         editingAutomationId = nil
-        formTitleLabel.stringValue = "New automation"
+        formTitleLabel.stringValue = String(localized: "settings.automations.form.new_title", defaultValue: "New automation", bundle: .macOSBridge)
         nameField.stringValue = ""
         rebuildTriggerOptions()
         rebuildDeviceOptions()
@@ -435,7 +458,7 @@ class AutomationsSection: SettingsCard {
 
     private func showEditForm(_ automation: Automation) {
         editingAutomationId = automation.id
-        formTitleLabel.stringValue = "Edit automation"
+        formTitleLabel.stringValue = String(localized: "settings.automations.form.edit_title", defaultValue: "Edit automation", bundle: .macOSBridge)
         nameField.stringValue = automation.name
         rebuildTriggerOptions()
         rebuildDeviceOptions()
@@ -506,10 +529,10 @@ class AutomationsSection: SettingsCard {
         guard let s = sender.identifier?.rawValue, let id = UUID(uuidString: s),
               let automation = AutomationStore.shared.automation(id: id) else { return }
         let alert = NSAlert()
-        alert.messageText = "Delete \"\(automation.name)\"?"
-        alert.informativeText = "This automation will be removed."
-        alert.addButton(withTitle: "Delete")
-        alert.addButton(withTitle: "Cancel")
+        alert.messageText = String(localized: "settings.automations.delete_alert.title", defaultValue: "Delete \"\(automation.name)\"?", bundle: .macOSBridge)
+        alert.informativeText = String(localized: "settings.automations.delete_alert.message", defaultValue: "This automation will be removed.", bundle: .macOSBridge)
+        alert.addButton(withTitle: String(localized: "common.delete", defaultValue: "Delete", bundle: .macOSBridge))
+        alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel", bundle: .macOSBridge))
         guard alert.runModal() == .alertFirstButtonReturn else { return }
         AutomationStore.shared.remove(id: id)
         AutomationEngine.shared.reload()

--- a/macOSBridge/Settings/Sections/HomeKitBridgeSection.swift
+++ b/macOSBridge/Settings/Sections/HomeKitBridgeSection.swift
@@ -58,7 +58,7 @@ class HomeKitBridgeSection: SettingsCard {
         }
 
         let desc = wrappingLabel(
-            "Publish virtual sensors to Apple Home over HomeKit. Rooms are assigned in Apple Home after pairing.")
+            String(localized: "settings.homekit_bridge.description", defaultValue: "Publish virtual sensors to Apple Home over HomeKit. Rooms are assigned in Apple Home after pairing.", bundle: .macOSBridge))
         stackView.addArrangedSubview(desc)
         stackView.addArrangedSubview(createSpacer(height: 10))
 
@@ -92,7 +92,7 @@ class HomeKitBridgeSection: SettingsCard {
         let container = NSView()
         container.translatesAutoresizingMaskIntoConstraints = false
 
-        let label = createLabel("Enable HomeKit Bridge", style: .body)
+        let label = createLabel(String(localized: "settings.homekit_bridge.enable_toggle", defaultValue: "Enable HomeKit Bridge", bundle: .macOSBridge), style: .body)
         label.translatesAutoresizingMaskIntoConstraints = false
 
         enableSwitch.controlSize = .mini
@@ -124,10 +124,10 @@ class HomeKitBridgeSection: SettingsCard {
         statusRow.orientation = .horizontal
         statusRow.spacing = 6
         statusRow.alignment = .centerY
-        let statusTitle = createLabel("Status:", style: .body)
+        let statusTitle = createLabel(String(localized: "settings.homekit_bridge.status_label", defaultValue: "Status:", bundle: .macOSBridge), style: .body)
         statusTitle.translatesAutoresizingMaskIntoConstraints = false
         statusTitle.widthAnchor.constraint(equalToConstant: 80).isActive = true
-        statusLabel = createLabel("Stopped", style: .body)
+        statusLabel = createLabel(String(localized: "settings.homekit_bridge.status.stopped", defaultValue: "Stopped", bundle: .macOSBridge), style: .body)
         statusRow.addArrangedSubview(statusTitle)
         statusRow.addArrangedSubview(statusLabel)
         stack.addArrangedSubview(statusRow)
@@ -137,19 +137,19 @@ class HomeKitBridgeSection: SettingsCard {
         codeRow.orientation = .horizontal
         codeRow.spacing = 8
         codeRow.alignment = .centerY
-        let codeTitle = createLabel("Setup code:", style: .body)
+        let codeTitle = createLabel(String(localized: "settings.homekit_bridge.setup_code_label", defaultValue: "Setup code:", bundle: .macOSBridge), style: .body)
         codeTitle.translatesAutoresizingMaskIntoConstraints = false
         codeTitle.widthAnchor.constraint(equalToConstant: 80).isActive = true
         codeLabel = createLabel(PreferencesManager.shared.virtualBridgeSetupCode, style: .code)
 
         let infoButton = NSButton(title: "", target: self, action: #selector(showInstructions(_:)))
-        infoButton.image = NSImage(systemSymbolName: "info.circle", accessibilityDescription: "How to pair")
+        infoButton.image = NSImage(systemSymbolName: "info.circle", accessibilityDescription: String(localized: "settings.homekit_bridge.info.accessibility", defaultValue: "How to pair", bundle: .macOSBridge))
         infoButton.imagePosition = .imageOnly
         infoButton.isBordered = false
         infoButton.contentTintColor = .secondaryLabelColor
-        infoButton.toolTip = "How to add this bridge to Apple Home"
+        infoButton.toolTip = String(localized: "settings.homekit_bridge.info.tooltip", defaultValue: "How to add this bridge to Apple Home", bundle: .macOSBridge)
 
-        let resetButton = NSButton(title: "Reset Pairing", target: self, action: #selector(resetPairingAction))
+        let resetButton = NSButton(title: String(localized: "settings.homekit_bridge.reset_pairing_button", defaultValue: "Reset Pairing", bundle: .macOSBridge), target: self, action: #selector(resetPairingAction))
         resetButton.bezelStyle = .rounded
         resetButton.controlSize = .small
 
@@ -171,11 +171,11 @@ class HomeKitBridgeSection: SettingsCard {
         row.alignment = .centerY
         row.translatesAutoresizingMaskIntoConstraints = false
 
-        let title = createLabel("Virtual devices", style: .sectionHeader)
+        let title = createLabel(String(localized: "settings.homekit_bridge.devices_header", defaultValue: "Virtual devices", bundle: .macOSBridge), style: .sectionHeader)
         row.addArrangedSubview(title)
         row.addArrangedSubview(NSView())  // spacer
 
-        let addButton = NSButton(title: "Add Device", target: self, action: #selector(showAddForm))
+        let addButton = NSButton(title: String(localized: "settings.homekit_bridge.add_device_button", defaultValue: "Add Device", bundle: .macOSBridge), target: self, action: #selector(showAddForm))
         addButton.bezelStyle = .rounded
         addButton.controlSize = .small
         row.addArrangedSubview(addButton)
@@ -192,10 +192,10 @@ class HomeKitBridgeSection: SettingsCard {
         panel.alignment = .leading
         panel.translatesAutoresizingMaskIntoConstraints = false
 
-        formTitleLabel = createLabel("New device", style: .sectionHeader)
+        formTitleLabel = createLabel(String(localized: "settings.homekit_bridge.form.new_title", defaultValue: "New device", bundle: .macOSBridge), style: .sectionHeader)
         panel.addArrangedSubview(formTitleLabel)
 
-        nameField.placeholderString = "Name (e.g. Front Door)"
+        nameField.placeholderString = String(localized: "settings.homekit_bridge.form.name_placeholder", defaultValue: "Name (e.g. Front Door)", bundle: .macOSBridge)
         nameField.controlSize = .regular
         panel.addArrangedSubview(labeledRow("Name", nameField))
 
@@ -214,7 +214,7 @@ class HomeKitBridgeSection: SettingsCard {
         criticalNote.textColor = .systemOrange
         panel.addArrangedSubview(criticalNote)
 
-        let note = wrappingLabel("The room is chosen in the Apple Home app after pairing.")
+        let note = wrappingLabel(String(localized: "settings.homekit_bridge.form.room_note", defaultValue: "The room is chosen in the Apple Home app after pairing.", bundle: .macOSBridge))
         note.textColor = .tertiaryLabelColor
         panel.addArrangedSubview(note)
 
@@ -228,12 +228,12 @@ class HomeKitBridgeSection: SettingsCard {
         buttons.alignment = .centerY
         buttons.translatesAutoresizingMaskIntoConstraints = false
         buttons.addArrangedSubview(NSView())  // spacer
-        let cancel = NSButton(title: "Cancel", target: self, action: #selector(cancelAdd))
+        let cancel = NSButton(title: String(localized: "settings.homekit_bridge.form.cancel_button", defaultValue: "Cancel", bundle: .macOSBridge), target: self, action: #selector(cancelAdd))
         cancel.bezelStyle = .rounded
         cancel.controlSize = .small
         cancel.keyEquivalent = "\u{1b}"  // Esc
         buttons.addArrangedSubview(cancel)
-        let save = NSButton(title: "Save", target: self, action: #selector(saveDevice))
+        let save = NSButton(title: String(localized: "settings.homekit_bridge.form.save_button", defaultValue: "Save", bundle: .macOSBridge), target: self, action: #selector(saveDevice))
         save.bezelStyle = .rounded
         save.controlSize = .small
         save.keyEquivalent = "\r"
@@ -281,7 +281,7 @@ class HomeKitBridgeSection: SettingsCard {
         }
         let devices = VirtualDeviceStore.shared.devices
         if devices.isEmpty {
-            devicesStack.addArrangedSubview(createLabel("No virtual devices yet.", style: .caption))
+            devicesStack.addArrangedSubview(createLabel(String(localized: "settings.homekit_bridge.devices_empty", defaultValue: "No virtual devices yet.", bundle: .macOSBridge), style: .caption))
             return
         }
         for device in devices {
@@ -312,7 +312,7 @@ class HomeKitBridgeSection: SettingsCard {
                                    target: self, action: #selector(deviceToggled(_:)))
         stateButton.bezelStyle = .rounded
         stateButton.controlSize = .small
-        stateButton.toolTip = "Toggle state"
+        stateButton.toolTip = String(localized: "settings.homekit_bridge.toggle_state.tooltip", defaultValue: "Toggle state", bundle: .macOSBridge)
         stateButton.identifier = NSUserInterfaceItemIdentifier(device.id.uuidString)
         stateButton.contentTintColor = device.state ? .controlAccentColor : .secondaryLabelColor
         stateButton.translatesAutoresizingMaskIntoConstraints = false
@@ -357,7 +357,7 @@ class HomeKitBridgeSection: SettingsCard {
 
     @objc private func showAddForm() {
         editingDeviceId = nil
-        formTitleLabel.stringValue = "New device"
+        formTitleLabel.stringValue = String(localized: "settings.homekit_bridge.form.new_title", defaultValue: "New device", bundle: .macOSBridge)
         nameField.stringValue = ""
         typePopUp.selectItem(at: 0)
         rolePopUp.selectItem(at: 0)
@@ -369,7 +369,7 @@ class HomeKitBridgeSection: SettingsCard {
 
     private func showEditForm(_ device: VirtualDevice) {
         editingDeviceId = device.id
-        formTitleLabel.stringValue = "Edit device"
+        formTitleLabel.stringValue = String(localized: "settings.homekit_bridge.form.edit_title", defaultValue: "Edit device", bundle: .macOSBridge)
         nameField.stringValue = device.name
         if let idx = orderedTypes.firstIndex(of: device.type) { typePopUp.selectItem(at: idx) }
         if let role = device.role, let idx = orderedRoles.firstIndex(of: role) {
@@ -394,13 +394,13 @@ class HomeKitBridgeSection: SettingsCard {
         roleRow.isHidden = (type != .contact)
         criticalNote.isHidden = !type.isCriticalAlertType
         criticalNote.stringValue = type.isCriticalAlertType
-            ? "Apple Home can raise critical alerts for \(displayName(type)) sensors."
+            ? String(localized: "settings.homekit_bridge.form.critical_note", defaultValue: "Apple Home can raise critical alerts for \(displayName(type)) sensors.", bundle: .macOSBridge)
             : ""
     }
 
     @objc private func saveDevice() {
         let name = nameField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !name.isEmpty else { addErrorLabel.stringValue = "Name is required."; return }
+        guard !name.isEmpty else { addErrorLabel.stringValue = String(localized: "settings.homekit_bridge.form.error.name_required", defaultValue: "Name is required.", bundle: .macOSBridge); return }
         let type = orderedTypes[typePopUp.indexOfSelectedItem]
         let role = orderedRoles[rolePopUp.indexOfSelectedItem]
 
@@ -408,7 +408,7 @@ class HomeKitBridgeSection: SettingsCard {
             let clash = VirtualDeviceStore.shared.devices.contains {
                 $0.id != editId && $0.name.lowercased() == name.lowercased()
             }
-            if clash { addErrorLabel.stringValue = "A device named \"\(name)\" already exists."; return }
+            if clash { addErrorLabel.stringValue = String(localized: "error.virtual_device.duplicate_name", defaultValue: "A device named \"\(name)\" already exists.", bundle: .macOSBridge); return }
             device.name = name
             device.type = type
             device.role = type == .contact ? role : nil
@@ -439,16 +439,16 @@ class HomeKitBridgeSection: SettingsCard {
             automation.actions.contains { if case .setVirtualSensor(let a) = $0 { return a.deviceId == id }; return false }
         }
         let alert = NSAlert()
-        alert.messageText = "Delete \"\(device.name)\"?"
+        alert.messageText = String(localized: "settings.homekit_bridge.delete_alert.title", defaultValue: "Delete \"\(device.name)\"?", bundle: .macOSBridge)
         if usedBy.isEmpty {
-            alert.informativeText = "This virtual sensor will be removed from Apple Home."
+            alert.informativeText = String(localized: "settings.homekit_bridge.delete_alert.message", defaultValue: "This virtual sensor will be removed from Apple Home.", bundle: .macOSBridge)
         } else {
             let names = usedBy.map { "\u{2022} \($0.name)" }.joined(separator: "\n")
             let plural = usedBy.count == 1
-            alert.informativeText = "This sensor is used by \(usedBy.count) automation\(plural ? "" : "s"):\n\(names)\n\nDeleting it will break \(plural ? "that automation" : "those automations")."
+            alert.informativeText = String(localized: "settings.homekit_bridge.delete_alert.used_by", defaultValue: "This sensor is used by \(usedBy.count) automation\(plural ? "" : "s"):\n\(names)\n\nDeleting it will break \(plural ? "that automation" : "those automations").", bundle: .macOSBridge)
         }
-        alert.addButton(withTitle: "Delete")
-        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: String(localized: "common.delete", defaultValue: "Delete", bundle: .macOSBridge))
+        alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel", bundle: .macOSBridge))
         guard alert.runModal() == .alertFirstButtonReturn else { return }
 
         let aid = device.aid
@@ -477,10 +477,10 @@ class HomeKitBridgeSection: SettingsCard {
 
     @objc private func resetPairingAction() {
         let alert = NSAlert()
-        alert.messageText = "Reset HomeKit pairing?"
-        alert.informativeText = "This unpairs the bridge and generates a new setup code. Remove \"Itsyhome Bridge\" from the Apple Home app, then add it again with the new code."
-        alert.addButton(withTitle: "Reset")
-        alert.addButton(withTitle: "Cancel")
+        alert.messageText = String(localized: "settings.homekit_bridge.reset_alert.title", defaultValue: "Reset HomeKit pairing?", bundle: .macOSBridge)
+        alert.informativeText = String(localized: "settings.homekit_bridge.reset_alert.message", defaultValue: "This unpairs the bridge and generates a new setup code. Remove \"Itsyhome Bridge\" from the Apple Home app, then add it again with the new code.", bundle: .macOSBridge)
+        alert.addButton(withTitle: String(localized: "settings.homekit_bridge.reset_alert.confirm_button", defaultValue: "Reset", bundle: .macOSBridge))
+        alert.addButton(withTitle: String(localized: "settings.homekit_bridge.reset_alert.cancel_button", defaultValue: "Cancel", bundle: .macOSBridge))
         guard alert.runModal() == .alertFirstButtonReturn else { return }
         Task {
             await VirtualBridgeService.shared.resetPairing()
@@ -513,13 +513,13 @@ class HomeKitBridgeSection: SettingsCard {
     private func updateStatusDisplay() {
         switch VirtualBridgeService.shared.status {
         case .stopped:
-            statusLabel.stringValue = "Stopped"
+            statusLabel.stringValue = String(localized: "settings.homekit_bridge.status.stopped", defaultValue: "Stopped", bundle: .macOSBridge)
             statusLabel.textColor = .secondaryLabelColor
         case .running:
-            statusLabel.stringValue = "Running"
+            statusLabel.stringValue = String(localized: "settings.homekit_bridge.status.running", defaultValue: "Running", bundle: .macOSBridge)
             statusLabel.textColor = .systemGreen
         case .error(let message):
-            statusLabel.stringValue = "Error: \(message)"
+            statusLabel.stringValue = String(localized: "settings.homekit_bridge.status.error", defaultValue: "Error: \(message)", bundle: .macOSBridge)
             statusLabel.textColor = .systemRed
         }
     }
@@ -536,12 +536,12 @@ class HomeKitBridgeSection: SettingsCard {
         stack.alignment = .leading
         stack.translatesAutoresizingMaskIntoConstraints = false
 
-        stack.addArrangedSubview(createLabel("Add to Apple Home", style: .sectionHeader))
+        stack.addArrangedSubview(createLabel(String(localized: "settings.homekit_bridge.instructions.title", defaultValue: "Add to Apple Home", bundle: .macOSBridge), style: .sectionHeader))
         let steps = [
-            "1. Add a device and enable the bridge.",
-            "2. In the Home app: Add Accessory, then More options.",
-            "3. Pick \u{201C}Itsyhome Bridge\u{201D} and enter the setup code.",
-            "4. Assign each device to a room in the Home app."
+            String(localized: "settings.homekit_bridge.instructions.step1", defaultValue: "1. Add a device and enable the bridge.", bundle: .macOSBridge),
+            String(localized: "settings.homekit_bridge.instructions.step2", defaultValue: "2. In the Home app: Add Accessory, then More options.", bundle: .macOSBridge),
+            String(localized: "settings.homekit_bridge.instructions.step3", defaultValue: "3. Pick \u{201C}Itsyhome Bridge\u{201D} and enter the setup code.", bundle: .macOSBridge),
+            String(localized: "settings.homekit_bridge.instructions.step4", defaultValue: "4. Assign each device to a room in the Home app.", bundle: .macOSBridge)
         ]
         for step in steps {
             let l = createLabel(step, style: .body)
@@ -576,23 +576,15 @@ class HomeKitBridgeSection: SettingsCard {
         return label
     }
 
-    private func displayName(_ type: VirtualSensorType) -> String {
-        switch type {
-        case .contact: return "Contact"
-        case .motion: return "Motion"
-        case .occupancy: return "Occupancy"
-        case .leak: return "Leak"
-        case .smoke: return "Smoke"
-        case .carbonMonoxide: return "Carbon Monoxide"
-        case .carbonDioxide: return "Carbon Dioxide"
-        }
-    }
+    // Type names live on VirtualSensorType.displayName so the bridge and the
+    // automations trigger picker share one localized source.
+    private func displayName(_ type: VirtualSensorType) -> String { type.displayName }
 
     private func displayName(_ role: ContactRole) -> String {
         switch role {
-        case .generic: return "Generic"
-        case .door: return "Door"
-        case .window: return "Window"
+        case .generic: return String(localized: "settings.homekit_bridge.role.generic", defaultValue: "Generic", bundle: .macOSBridge)
+        case .door: return String(localized: "settings.homekit_bridge.role.door", defaultValue: "Door", bundle: .macOSBridge)
+        case .window: return String(localized: "settings.homekit_bridge.role.window", defaultValue: "Window", bundle: .macOSBridge)
         }
     }
 

--- a/macOSBridge/Settings/Sections/HomeKitBridgeSection.swift
+++ b/macOSBridge/Settings/Sections/HomeKitBridgeSection.swift
@@ -1,0 +1,605 @@
+//
+//  HomeKitBridgeSection.swift
+//  macOSBridge
+//
+//  Settings pane for the virtual HomeKit bridge: a master enable toggle, the
+//  pairing setup code + status + reset, and the managed list of virtual devices.
+//  Each device has a state toggle button to flip its reading and watch it move
+//  in Apple Home + the events feed. Pairing instructions live behind an info
+//  popover (one-time content), and the add/edit form replaces the list inline.
+//  Rooms are assigned in Apple Home after pairing.
+//
+import AppKit
+
+class HomeKitBridgeSection: SettingsCard {
+
+    private let enableSwitch = NSSwitch()
+    private var statusLabel: NSTextField!
+    private var codeLabel: NSTextField!
+
+    private var devicesHeader: NSView!
+    private let devicesStack = NSStackView()
+
+    // Inline add / edit form (replaces the device list while open)
+    private let addContainer = NSView()
+    private let nameField = NSTextField()
+    private let typePopUp = NSPopUpButton()
+    private let rolePopUp = NSPopUpButton()
+    private var roleRow: NSView!
+    private var criticalNote: NSTextField!
+    private var addErrorLabel: NSTextField!
+    private var formTitleLabel: NSTextField!
+    private var editingDeviceId: UUID?
+
+    private let orderedTypes: [VirtualSensorType] =
+        [.contact, .motion, .occupancy, .leak, .smoke, .carbonMonoxide, .carbonDioxide]
+    private let orderedRoles: [ContactRole] = [.generic, .door, .window]
+
+    private lazy var instructionsPopover: NSPopover = makeInstructionsPopover()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupContent()
+        observeNotifications()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit { NotificationCenter.default.removeObserver(self) }
+
+    // MARK: - Layout
+
+    private func setupContent() {
+        if !ProStatusCache.shared.isPro {
+            stackView.addArrangedSubview(Self.createProBanner())
+            stackView.addArrangedSubview(createSpacer(height: 8))
+        }
+
+        let desc = wrappingLabel(
+            "Publish virtual sensors to Apple Home over HomeKit. Rooms are assigned in Apple Home after pairing.")
+        stackView.addArrangedSubview(desc)
+        stackView.addArrangedSubview(createSpacer(height: 10))
+
+        stackView.addArrangedSubview(createEnableRow())
+        stackView.addArrangedSubview(createSpacer(height: 8))
+        stackView.addArrangedSubview(createStatusContent())
+        stackView.addArrangedSubview(createSpacer(height: 14))
+
+        devicesHeader = createDevicesHeader()
+        stackView.addArrangedSubview(devicesHeader)
+        devicesHeader.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+
+        devicesStack.orientation = .vertical
+        devicesStack.spacing = 6
+        devicesStack.alignment = .leading
+        devicesStack.translatesAutoresizingMaskIntoConstraints = false
+        stackView.addArrangedSubview(devicesStack)
+        devicesStack.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+
+        setupAddForm()
+        stackView.addArrangedSubview(addContainer)
+        addContainer.isHidden = true
+        addContainer.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+
+        enableSwitch.state = PreferencesManager.shared.virtualBridgeEnabled ? .on : .off
+        rebuildDevicesList()
+        updateStatusDisplay()
+    }
+
+    private func createEnableRow() -> NSView {
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        let label = createLabel("Enable HomeKit Bridge", style: .body)
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        enableSwitch.controlSize = .mini
+        enableSwitch.target = self
+        enableSwitch.action = #selector(enableSwitchChanged)
+        enableSwitch.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(label)
+        container.addSubview(enableSwitch)
+
+        NSLayoutConstraint.activate([
+            container.heightAnchor.constraint(equalToConstant: 36),
+            label.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            label.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: enableSwitch.leadingAnchor, constant: -16),
+            enableSwitch.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            enableSwitch.centerYAnchor.constraint(equalTo: container.centerYAnchor)
+        ])
+        return container
+    }
+
+    private func createStatusContent() -> NSView {
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.spacing = 6
+        stack.alignment = .leading
+
+        let statusRow = NSStackView()
+        statusRow.orientation = .horizontal
+        statusRow.spacing = 6
+        statusRow.alignment = .centerY
+        let statusTitle = createLabel("Status:", style: .body)
+        statusTitle.translatesAutoresizingMaskIntoConstraints = false
+        statusTitle.widthAnchor.constraint(equalToConstant: 80).isActive = true
+        statusLabel = createLabel("Stopped", style: .body)
+        statusRow.addArrangedSubview(statusTitle)
+        statusRow.addArrangedSubview(statusLabel)
+        stack.addArrangedSubview(statusRow)
+
+        // Setup code, an info affordance for the (one-time) pairing steps, and reset.
+        let codeRow = NSStackView()
+        codeRow.orientation = .horizontal
+        codeRow.spacing = 8
+        codeRow.alignment = .centerY
+        let codeTitle = createLabel("Setup code:", style: .body)
+        codeTitle.translatesAutoresizingMaskIntoConstraints = false
+        codeTitle.widthAnchor.constraint(equalToConstant: 80).isActive = true
+        codeLabel = createLabel(PreferencesManager.shared.virtualBridgeSetupCode, style: .code)
+
+        let infoButton = NSButton(title: "", target: self, action: #selector(showInstructions(_:)))
+        infoButton.image = NSImage(systemSymbolName: "info.circle", accessibilityDescription: "How to pair")
+        infoButton.imagePosition = .imageOnly
+        infoButton.isBordered = false
+        infoButton.contentTintColor = .secondaryLabelColor
+        infoButton.toolTip = "How to add this bridge to Apple Home"
+
+        let resetButton = NSButton(title: "Reset Pairing", target: self, action: #selector(resetPairingAction))
+        resetButton.bezelStyle = .rounded
+        resetButton.controlSize = .small
+
+        codeRow.addArrangedSubview(codeTitle)
+        codeRow.addArrangedSubview(codeLabel)
+        codeRow.addArrangedSubview(infoButton)
+        codeRow.addArrangedSubview(NSView())  // spacer pushes reset to the right
+        codeRow.addArrangedSubview(resetButton)
+        stack.addArrangedSubview(codeRow)
+        codeRow.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+
+        return stack
+    }
+
+    private func createDevicesHeader() -> NSView {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.spacing = 8
+        row.alignment = .centerY
+        row.translatesAutoresizingMaskIntoConstraints = false
+
+        let title = createLabel("Virtual devices", style: .sectionHeader)
+        row.addArrangedSubview(title)
+        row.addArrangedSubview(NSView())  // spacer
+
+        let addButton = NSButton(title: "Add Device", target: self, action: #selector(showAddForm))
+        addButton.bezelStyle = .rounded
+        addButton.controlSize = .small
+        row.addArrangedSubview(addButton)
+
+        return row
+    }
+
+    // MARK: - Add / edit form
+
+    private func setupAddForm() {
+        let panel = NSStackView()
+        panel.orientation = .vertical
+        panel.spacing = 8
+        panel.alignment = .leading
+        panel.translatesAutoresizingMaskIntoConstraints = false
+
+        formTitleLabel = createLabel("New device", style: .sectionHeader)
+        panel.addArrangedSubview(formTitleLabel)
+
+        nameField.placeholderString = "Name (e.g. Front Door)"
+        nameField.controlSize = .regular
+        panel.addArrangedSubview(labeledRow("Name", nameField))
+
+        for type in orderedTypes { typePopUp.addItem(withTitle: displayName(type)) }
+        typePopUp.controlSize = .regular
+        typePopUp.target = self
+        typePopUp.action = #selector(typeChanged)
+        panel.addArrangedSubview(labeledRow("Type", typePopUp))
+
+        for role in orderedRoles { rolePopUp.addItem(withTitle: displayName(role)) }
+        rolePopUp.controlSize = .regular
+        roleRow = labeledRow("Role", rolePopUp)
+        panel.addArrangedSubview(roleRow)
+
+        criticalNote = wrappingLabel("")
+        criticalNote.textColor = .systemOrange
+        panel.addArrangedSubview(criticalNote)
+
+        let note = wrappingLabel("The room is chosen in the Apple Home app after pairing.")
+        note.textColor = .tertiaryLabelColor
+        panel.addArrangedSubview(note)
+
+        addErrorLabel = createLabel("", style: .caption)
+        addErrorLabel.textColor = .systemRed
+        panel.addArrangedSubview(addErrorLabel)
+
+        let buttons = NSStackView()
+        buttons.orientation = .horizontal
+        buttons.spacing = 8
+        buttons.alignment = .centerY
+        buttons.translatesAutoresizingMaskIntoConstraints = false
+        buttons.addArrangedSubview(NSView())  // spacer
+        let cancel = NSButton(title: "Cancel", target: self, action: #selector(cancelAdd))
+        cancel.bezelStyle = .rounded
+        cancel.controlSize = .small
+        cancel.keyEquivalent = "\u{1b}"  // Esc
+        buttons.addArrangedSubview(cancel)
+        let save = NSButton(title: "Save", target: self, action: #selector(saveDevice))
+        save.bezelStyle = .rounded
+        save.controlSize = .small
+        save.keyEquivalent = "\r"
+        buttons.addArrangedSubview(save)
+        panel.addArrangedSubview(buttons)
+        buttons.widthAnchor.constraint(equalTo: panel.widthAnchor).isActive = true
+
+        addContainer.addSubview(panel)
+        NSLayoutConstraint.activate([
+            panel.topAnchor.constraint(equalTo: addContainer.topAnchor),
+            panel.leadingAnchor.constraint(equalTo: addContainer.leadingAnchor),
+            panel.trailingAnchor.constraint(equalTo: addContainer.trailingAnchor),
+            panel.bottomAnchor.constraint(equalTo: addContainer.bottomAnchor)
+        ])
+    }
+
+    private func labeledRow(_ label: String, _ control: NSView) -> NSView {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.spacing = 8
+        row.alignment = .centerY
+        row.translatesAutoresizingMaskIntoConstraints = false
+        let l = createLabel(label, style: .body)
+        l.translatesAutoresizingMaskIntoConstraints = false
+        l.widthAnchor.constraint(equalToConstant: 110).isActive = true
+        control.translatesAutoresizingMaskIntoConstraints = false
+        row.addArrangedSubview(l)
+        row.addArrangedSubview(control)
+        return row
+    }
+
+    /// Swap the device list for the add/edit form (and back).
+    private func setFormVisible(_ visible: Bool) {
+        devicesHeader.isHidden = visible
+        devicesStack.isHidden = visible
+        addContainer.isHidden = !visible
+    }
+
+    // MARK: - Device list
+
+    private func rebuildDevicesList() {
+        for view in devicesStack.arrangedSubviews {
+            devicesStack.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
+        let devices = VirtualDeviceStore.shared.devices
+        if devices.isEmpty {
+            devicesStack.addArrangedSubview(createLabel("No virtual devices yet.", style: .caption))
+            return
+        }
+        for device in devices {
+            let row = createDeviceRow(device)
+            devicesStack.addArrangedSubview(row)
+            row.widthAnchor.constraint(equalTo: devicesStack.widthAnchor).isActive = true
+        }
+    }
+
+    private func createDeviceRow(_ device: VirtualDevice) -> NSView {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.spacing = 8
+        row.alignment = .centerY
+        row.translatesAutoresizingMaskIntoConstraints = false
+
+        let name = createLabel(device.name, style: .body)
+        row.addArrangedSubview(name)
+
+        let detail = createLabel(displayName(device.type), style: .caption)
+        detail.textColor = .secondaryLabelColor
+        row.addArrangedSubview(detail)
+
+        row.addArrangedSubview(NSView())  // spacer
+
+        // State toggle BUTTON - clicking flips the reading (not a power switch).
+        let stateButton = NSButton(title: device.type.stateWord(on: device.state),
+                                   target: self, action: #selector(deviceToggled(_:)))
+        stateButton.bezelStyle = .rounded
+        stateButton.controlSize = .small
+        stateButton.toolTip = "Toggle state"
+        stateButton.identifier = NSUserInterfaceItemIdentifier(device.id.uuidString)
+        stateButton.contentTintColor = device.state ? .controlAccentColor : .secondaryLabelColor
+        stateButton.translatesAutoresizingMaskIntoConstraints = false
+        stateButton.widthAnchor.constraint(greaterThanOrEqualToConstant: 72).isActive = true
+        row.addArrangedSubview(stateButton)
+
+        row.addArrangedSubview(iconButton("pencil", action: #selector(editDeviceAction(_:)), id: device.id))
+        row.addArrangedSubview(iconButton("xmark.circle.fill", action: #selector(removeDeviceAction(_:)), id: device.id))
+
+        row.heightAnchor.constraint(equalToConstant: 28).isActive = true
+        return row
+    }
+
+    private func iconButton(_ symbol: String, action: Selector, id: UUID) -> NSButton {
+        let button = NSButton(title: "", target: self, action: action)
+        button.image = NSImage(systemSymbolName: symbol, accessibilityDescription: nil)
+        button.imagePosition = .imageOnly
+        button.isBordered = false
+        button.contentTintColor = .secondaryLabelColor
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.widthAnchor.constraint(equalToConstant: 20).isActive = true
+        button.heightAnchor.constraint(equalToConstant: 20).isActive = true
+        button.identifier = NSUserInterfaceItemIdentifier(id.uuidString)
+        return button
+    }
+
+    // MARK: - Actions
+
+    @objc private func enableSwitchChanged(_ sender: NSSwitch) {
+        let enabled = sender.state == .on
+        PreferencesManager.shared.virtualBridgeEnabled = enabled
+        if enabled {
+            VirtualBridgeService.shared.startIfEnabled()
+        } else {
+            Task { await VirtualBridgeService.shared.stop() }
+        }
+    }
+
+    @objc private func showInstructions(_ sender: NSButton) {
+        instructionsPopover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .maxY)
+    }
+
+    @objc private func showAddForm() {
+        editingDeviceId = nil
+        formTitleLabel.stringValue = "New device"
+        nameField.stringValue = ""
+        typePopUp.selectItem(at: 0)
+        rolePopUp.selectItem(at: 0)
+        addErrorLabel.stringValue = ""
+        typeChanged()
+        setFormVisible(true)
+        window?.makeFirstResponder(nameField)
+    }
+
+    private func showEditForm(_ device: VirtualDevice) {
+        editingDeviceId = device.id
+        formTitleLabel.stringValue = "Edit device"
+        nameField.stringValue = device.name
+        if let idx = orderedTypes.firstIndex(of: device.type) { typePopUp.selectItem(at: idx) }
+        if let role = device.role, let idx = orderedRoles.firstIndex(of: role) {
+            rolePopUp.selectItem(at: idx)
+        } else {
+            rolePopUp.selectItem(at: 0)
+        }
+        addErrorLabel.stringValue = ""
+        typeChanged()
+        setFormVisible(true)
+        window?.makeFirstResponder(nameField)
+    }
+
+    @objc private func cancelAdd() {
+        editingDeviceId = nil
+        setFormVisible(false)
+    }
+
+    /// Role only applies to contact; the safety sensors carry a critical-alert note.
+    @objc private func typeChanged() {
+        let type = orderedTypes[typePopUp.indexOfSelectedItem]
+        roleRow.isHidden = (type != .contact)
+        criticalNote.isHidden = !type.isCriticalAlertType
+        criticalNote.stringValue = type.isCriticalAlertType
+            ? "Apple Home can raise critical alerts for \(displayName(type)) sensors."
+            : ""
+    }
+
+    @objc private func saveDevice() {
+        let name = nameField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { addErrorLabel.stringValue = "Name is required."; return }
+        let type = orderedTypes[typePopUp.indexOfSelectedItem]
+        let role = orderedRoles[rolePopUp.indexOfSelectedItem]
+
+        if let editId = editingDeviceId, var device = VirtualDeviceStore.shared.device(id: editId) {
+            let clash = VirtualDeviceStore.shared.devices.contains {
+                $0.id != editId && $0.name.lowercased() == name.lowercased()
+            }
+            if clash { addErrorLabel.stringValue = "A device named \"\(name)\" already exists."; return }
+            device.name = name
+            device.type = type
+            device.role = type == .contact ? role : nil
+            VirtualDeviceStore.shared.update(device)
+            editingDeviceId = nil
+            Task { await VirtualBridgeService.shared.updateDevice(device) }
+            setFormVisible(false)
+            rebuildDevicesList()
+        } else {
+            do {
+                let device = try VirtualDeviceStore.shared.add(
+                    name: name, type: type, role: role, room: nil)
+                Task { await VirtualBridgeService.shared.addDevice(device) }
+                setFormVisible(false)
+                rebuildDevicesList()
+            } catch {
+                addErrorLabel.stringValue = error.localizedDescription
+            }
+        }
+    }
+
+    @objc private func removeDeviceAction(_ sender: NSButton) {
+        guard let idString = sender.identifier?.rawValue,
+              let id = UUID(uuidString: idString),
+              let device = VirtualDeviceStore.shared.device(id: id) else { return }
+
+        let usedBy = AutomationStore.shared.automations.filter { automation in
+            automation.actions.contains { if case .setVirtualSensor(let a) = $0 { return a.deviceId == id }; return false }
+        }
+        let alert = NSAlert()
+        alert.messageText = "Delete \"\(device.name)\"?"
+        if usedBy.isEmpty {
+            alert.informativeText = "This virtual sensor will be removed from Apple Home."
+        } else {
+            let names = usedBy.map { "\u{2022} \($0.name)" }.joined(separator: "\n")
+            let plural = usedBy.count == 1
+            alert.informativeText = "This sensor is used by \(usedBy.count) automation\(plural ? "" : "s"):\n\(names)\n\nDeleting it will break \(plural ? "that automation" : "those automations")."
+        }
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        let aid = device.aid
+        VirtualDeviceStore.shared.remove(id: id)
+        Task { await VirtualBridgeService.shared.removeDevice(aid: aid) }
+        AutomationEngine.shared.reload()   // drop/stop any automation that depended on it
+        rebuildDevicesList()
+    }
+
+    @objc private func editDeviceAction(_ sender: NSButton) {
+        guard let idString = sender.identifier?.rawValue,
+              let id = UUID(uuidString: idString),
+              let device = VirtualDeviceStore.shared.device(id: id) else { return }
+        showEditForm(device)
+    }
+
+    @objc private func deviceToggled(_ sender: NSButton) {
+        guard let idString = sender.identifier?.rawValue,
+              let id = UUID(uuidString: idString),
+              let device = VirtualDeviceStore.shared.device(id: id) else { return }
+        let newState = !device.state
+        VirtualControl.setState(device, on: newState)
+        sender.title = device.type.stateWord(on: newState)
+        sender.contentTintColor = newState ? .controlAccentColor : .secondaryLabelColor
+    }
+
+    @objc private func resetPairingAction() {
+        let alert = NSAlert()
+        alert.messageText = "Reset HomeKit pairing?"
+        alert.informativeText = "This unpairs the bridge and generates a new setup code. Remove \"Itsyhome Bridge\" from the Apple Home app, then add it again with the new code."
+        alert.addButton(withTitle: "Reset")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        Task {
+            await VirtualBridgeService.shared.resetPairing()
+            await MainActor.run {
+                self.codeLabel.stringValue = PreferencesManager.shared.virtualBridgeSetupCode
+                self.updateStatusDisplay()
+            }
+        }
+    }
+
+    // MARK: - Status
+
+    private func observeNotifications() {
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(statusDidChange),
+            name: VirtualBridgeService.statusChangedNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(storeDidChange),
+            name: VirtualDeviceStore.didChangeNotification, object: nil)
+    }
+
+    @objc private func statusDidChange() {
+        DispatchQueue.main.async { [weak self] in self?.updateStatusDisplay() }
+    }
+
+    @objc private func storeDidChange() {
+        DispatchQueue.main.async { [weak self] in self?.rebuildDevicesList() }
+    }
+
+    private func updateStatusDisplay() {
+        switch VirtualBridgeService.shared.status {
+        case .stopped:
+            statusLabel.stringValue = "Stopped"
+            statusLabel.textColor = .secondaryLabelColor
+        case .running:
+            statusLabel.stringValue = "Running"
+            statusLabel.textColor = .systemGreen
+        case .error(let message):
+            statusLabel.stringValue = "Error: \(message)"
+            statusLabel.textColor = .systemRed
+        }
+    }
+
+    // MARK: - Instructions popover
+
+    private func makeInstructionsPopover() -> NSPopover {
+        let pop = NSPopover()
+        pop.behavior = .transient
+
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.spacing = 8
+        stack.alignment = .leading
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        stack.addArrangedSubview(createLabel("Add to Apple Home", style: .sectionHeader))
+        let steps = [
+            "1. Add a device and enable the bridge.",
+            "2. In the Home app: Add Accessory, then More options.",
+            "3. Pick \u{201C}Itsyhome Bridge\u{201D} and enter the setup code.",
+            "4. Assign each device to a room in the Home app."
+        ]
+        for step in steps {
+            let l = createLabel(step, style: .body)
+            l.lineBreakMode = .byWordWrapping
+            l.maximumNumberOfLines = 0
+            l.preferredMaxLayoutWidth = 280
+            stack.addArrangedSubview(l)
+        }
+
+        let container = NSView()
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: 16),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -16)
+        ])
+        let vc = NSViewController()
+        vc.view = container
+        pop.contentViewController = vc
+        pop.contentSize = NSSize(width: 320, height: 188)
+        return pop
+    }
+
+    // MARK: - Helpers
+
+    private func wrappingLabel(_ text: String) -> NSTextField {
+        let label = createLabel(text, style: .caption)
+        label.lineBreakMode = .byWordWrapping
+        label.maximumNumberOfLines = 0
+        label.preferredMaxLayoutWidth = 460
+        return label
+    }
+
+    private func displayName(_ type: VirtualSensorType) -> String {
+        switch type {
+        case .contact: return "Contact"
+        case .motion: return "Motion"
+        case .occupancy: return "Occupancy"
+        case .leak: return "Leak"
+        case .smoke: return "Smoke"
+        case .carbonMonoxide: return "Carbon Monoxide"
+        case .carbonDioxide: return "Carbon Dioxide"
+        }
+    }
+
+    private func displayName(_ role: ContactRole) -> String {
+        switch role {
+        case .generic: return "Generic"
+        case .door: return "Door"
+        case .window: return "Window"
+        }
+    }
+
+    private func createSpacer(height: CGFloat) -> NSView {
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.heightAnchor.constraint(equalToConstant: height).isActive = true
+        return spacer
+    }
+}

--- a/macOSBridge/Settings/SettingsView.swift
+++ b/macOSBridge/Settings/SettingsView.swift
@@ -73,6 +73,8 @@ class SettingsView: NSView, NSTableViewDataSource, NSTableViewDelegate {
         case advanced
         case deeplinks
         case webhooks
+        case homeKitBridge
+        case automations
         case itsyhomeIOS
         case itsytv
         case about
@@ -87,6 +89,8 @@ class SettingsView: NSView, NSTableViewDataSource, NSTableViewDelegate {
             case .advanced: return String(localized: "settings.advanced.title", defaultValue: "Advanced", bundle: .macOSBridge)
             case .deeplinks: return String(localized: "settings.deeplinks.title", defaultValue: "Deeplinks", bundle: .macOSBridge)
             case .webhooks: return String(localized: "settings.webhooks.title", defaultValue: "Webhooks/CLI", bundle: .macOSBridge)
+            case .homeKitBridge: return String(localized: "settings.homekit_bridge.title", defaultValue: "HomeKit Bridge", bundle: .macOSBridge)
+            case .automations: return String(localized: "settings.automations.title", defaultValue: "Automations", bundle: .macOSBridge)
             case .itsyhomeIOS: return String(localized: "settings.itsyhome_ios.section_title", defaultValue: "Itsyhome for iOS", bundle: .macOSBridge)
             case .itsytv: return String(localized: "settings.itsytv.title", defaultValue: "Apple TV remote", bundle: .macOSBridge)
             case .about: return String(localized: "settings.about.title", defaultValue: "About", bundle: .macOSBridge)
@@ -103,6 +107,8 @@ class SettingsView: NSView, NSTableViewDataSource, NSTableViewDelegate {
             case .advanced: return "sliders-horizontal"
             case .deeplinks: return "link"
             case .webhooks: return "globe"
+            case .homeKitBridge: return "bridge"
+            case .automations: return "flow-arrow"
             case .itsyhomeIOS: return "device-mobile"
             case .itsytv: return "television"
             case .about: return "info"
@@ -111,7 +117,7 @@ class SettingsView: NSView, NSTableViewDataSource, NSTableViewDelegate {
 
         var isProFeature: Bool {
             switch self {
-            case .cameras, .networks, .deeplinks, .webhooks, .itsyhomeIOS: return true
+            case .cameras, .networks, .deeplinks, .webhooks, .itsyhomeIOS, .homeKitBridge, .automations: return true
             default: return false
             }
         }
@@ -145,6 +151,8 @@ class SettingsView: NSView, NSTableViewDataSource, NSTableViewDelegate {
     private var advancedSection: AdvancedSection?
     private var deeplinksSection: DeeplinksSection?
     private var webhooksSection: WebhooksSection?
+    private var homeKitBridgeSection: HomeKitBridgeSection?
+    private var automationsSection: AutomationsSection?
     private var itsyhomeIOSSection: ItsyhomeIOSSection?
     private var itsytvSection: ItsytvSection?
     private var aboutSection: AboutSection?
@@ -164,6 +172,7 @@ class SettingsView: NSView, NSTableViewDataSource, NSTableViewDelegate {
         accessoriesSection?.configure(with: data)
         camerasSection?.configure(with: data)
         networksSection?.configure(with: data)
+        automationsSection?.configure(with: data)
     }
 
     override func viewDidMoveToWindow() {
@@ -335,6 +344,21 @@ class SettingsView: NSView, NSTableViewDataSource, NSTableViewDelegate {
                 webhooksSection = WebhooksSection()
             }
             contentView = webhooksSection!
+
+        case .homeKitBridge:
+            if homeKitBridgeSection == nil {
+                homeKitBridgeSection = HomeKitBridgeSection()
+            }
+            contentView = homeKitBridgeSection!
+
+        case .automations:
+            if automationsSection == nil {
+                automationsSection = AutomationsSection()
+                if let data = menuData {
+                    automationsSection?.configure(with: data)
+                }
+            }
+            contentView = automationsSection!
 
         case .itsyhomeIOS:
             if itsyhomeIOSSection == nil {

--- a/macOSBridge/Settings/SettingsView.swift
+++ b/macOSBridge/Settings/SettingsView.swift
@@ -128,6 +128,11 @@ class SettingsView: NSView, NSTableViewDataSource, NSTableViewDelegate {
             switch self {
             case .homeAssistant:
                 return platform == .homeAssistant
+            case .homeKitBridge, .automations:
+                // Virtual sensors and the automations that drive them depend on
+                // the Apple Home -> HomeKit notify -> ItsyHome round-trip, which
+                // does not exist in Home Assistant mode. HomeKit-only.
+                return platform == .homeKit
             case .accessories:
                 // Show Home section for both platforms (different content)
                 return true

--- a/macOSBridgeTests/AutomationBuilderTests.swift
+++ b/macOSBridgeTests/AutomationBuilderTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import macOSBridge
+
+final class AutomationBuilderTests: XCTestCase {
+    func test_validation_requiresTriggerActionAndName() {
+        XCTAssertNotNil(AutomationDraft(name: "", trigger: nil, durationSeconds: 0, actionDeviceId: nil).validationError())
+
+        let ok = AutomationDraft(name: "Door", trigger: AccessoryStateTrigger(characteristicId: UUID(),
+            accessoryName: "D", characteristicLabel: "C", comparator: .equal, value: 1),
+            durationSeconds: 900, actionDeviceId: UUID())
+        XCTAssertNil(ok.validationError())
+        XCTAssertEqual(ok.build().conditions, [.duration(seconds: 900)])
+    }
+
+    func test_zeroDuration_buildsNoCondition() {
+        let d = AutomationDraft(name: "x", trigger: AccessoryStateTrigger(characteristicId: UUID(),
+            accessoryName: "D", characteristicLabel: "C", comparator: .equal, value: 1),
+            durationSeconds: 0, actionDeviceId: UUID())
+        XCTAssertTrue(d.build().conditions.isEmpty)
+    }
+}

--- a/macOSBridgeTests/AutomationEngineCoreTests.swift
+++ b/macOSBridgeTests/AutomationEngineCoreTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import macOSBridge
+
+final class AutomationEngineCoreTests: XCTestCase {
+    private func automation(char cid: UUID, duration: Int?) -> Automation {
+        Automation(id: UUID(), name: "x", enabled: true,
+            trigger: .accessoryState(AccessoryStateTrigger(characteristicId: cid,
+                accessoryName: "D", characteristicLabel: "C", comparator: .equal, value: 1)),
+            conditions: duration.map { [.duration(seconds: $0)] } ?? [],
+            actions: [])
+    }
+
+    func test_trigger_satisfied_withDuration_wantsArming() {
+        let cid = UUID()
+        let r = automation(char: cid, duration: 900)
+        XCTAssertEqual(AutomationEvaluation.desiredPhase(for: r, characteristic: cid, value: 1), .arming(seconds: 900))
+        XCTAssertEqual(AutomationEvaluation.desiredPhase(for: r, characteristic: cid, value: 0), .idle)
+        XCTAssertNil(AutomationEvaluation.desiredPhase(for: r, characteristic: UUID(), value: 1)) // unrelated char
+    }
+
+    func test_trigger_satisfied_noDuration_wantsActiveNow() {
+        let cid = UUID()
+        let r = automation(char: cid, duration: nil)
+        XCTAssertEqual(AutomationEvaluation.desiredPhase(for: r, characteristic: cid, value: 1), .activeNow)
+    }
+
+    func test_disabledAutomation_isIdle() {
+        let cid = UUID()
+        var r = automation(char: cid, duration: 900); r.enabled = false
+        XCTAssertEqual(AutomationEvaluation.desiredPhase(for: r, characteristic: cid, value: 1), .idle)
+    }
+}

--- a/macOSBridgeTests/AutomationEngineRuntimeTests.swift
+++ b/macOSBridgeTests/AutomationEngineRuntimeTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import macOSBridge
+
+final class AutomationEngineRuntimeTests: XCTestCase {
+    func test_duration_fires_activation_afterDelay_andClearsOnRelease() {
+        let cid = UUID()
+        var activated: [Bool] = []
+        let engine = AutomationEngine(applyActive: { _, on in activated.append(on) }, deviceExists: { _ in true })
+        let automation = Automation(id: UUID(), name: "x", enabled: true,
+            trigger: .accessoryState(AccessoryStateTrigger(characteristicId: cid,
+                accessoryName: "D", characteristicLabel: "C", comparator: .equal, value: 1)),
+            conditions: [.duration(seconds: 0)],   // 0s -> activates almost immediately
+            actions: [.setVirtualSensor(SetVirtualSensorAction(deviceId: UUID(),
+                rePulse: .init(enabled: false, intervalSeconds: 60)))])
+        engine.load([automation])
+
+        engine.handleCharacteristicChange(id: cid, value: 1)
+        let activeExp = expectation(description: "activated")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            XCTAssertEqual(activated, [true]); activeExp.fulfill()
+        }
+        wait(for: [activeExp], timeout: 1)
+
+        engine.handleCharacteristicChange(id: cid, value: 0)  // door closes
+        let clearExp = expectation(description: "cleared")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            XCTAssertEqual(activated, [true, false]); clearExp.fulfill()
+        }
+        wait(for: [clearExp], timeout: 1)
+    }
+}

--- a/macOSBridgeTests/AutomationModelTests.swift
+++ b/macOSBridgeTests/AutomationModelTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import macOSBridge
+
+final class AutomationModelTests: XCTestCase {
+    func test_codable_roundTrip() throws {
+        let automation = Automation(
+            id: UUID(), name: "Front Door left open", enabled: true,
+            trigger: .accessoryState(AccessoryStateTrigger(
+                characteristicId: UUID(), accessoryName: "Front Door",
+                characteristicLabel: "Contact", comparator: .equal, value: 1)),
+            conditions: [.duration(seconds: 900)],
+            actions: [.setVirtualSensor(SetVirtualSensorAction(
+                deviceId: UUID(), rePulse: .init(enabled: true, intervalSeconds: 300)))])
+        let data = try JSONEncoder().encode(automation)
+        XCTAssertEqual(try JSONDecoder().decode(Automation.self, from: data), automation)
+    }
+
+    func test_comparator_matchesNumericValues() {
+        let t = AccessoryStateTrigger(characteristicId: UUID(), accessoryName: "D",
+            characteristicLabel: "Contact", comparator: .equal, value: 1)
+        XCTAssertTrue(t.isSatisfied(by: 1))
+        XCTAssertTrue(t.isSatisfied(by: true))     // Bool coerces
+        XCTAssertFalse(t.isSatisfied(by: 0))
+        XCTAssertNil(t.currentValueAsDouble(nil))   // missing -> nil
+    }
+
+    func test_durationSeconds_helper() {
+        let r = Automation(id: UUID(), name: "x", enabled: true,
+            trigger: .accessoryState(AccessoryStateTrigger(characteristicId: UUID(),
+                accessoryName: "D", characteristicLabel: "C", comparator: .equal, value: 1)),
+            conditions: [.duration(seconds: 600)], actions: [])
+        XCTAssertEqual(r.durationSeconds, 600)
+    }
+}

--- a/macOSBridgeTests/AutomationStoreTests.swift
+++ b/macOSBridgeTests/AutomationStoreTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import macOSBridge
+
+final class AutomationStoreTests: XCTestCase {
+    private func make(_ name: String) -> Automation {
+        Automation(id: UUID(), name: name, enabled: true,
+            trigger: .accessoryState(AccessoryStateTrigger(characteristicId: UUID(),
+                accessoryName: "D", characteristicLabel: "C", comparator: .equal, value: 1)),
+            conditions: [.duration(seconds: 900)], actions: [])
+    }
+
+    func test_crud_persists() {
+        let d = UserDefaults(suiteName: "AutomationStoreTests")!
+        d.removePersistentDomain(forName: "AutomationStoreTests")
+        let store = AutomationStore(defaults: d)
+        let r = make("A")
+        store.upsert(r)
+        XCTAssertEqual(AutomationStore(defaults: d).automations.count, 1)
+        var edited = r; edited.name = "B"
+        store.upsert(edited)
+        XCTAssertEqual(store.automation(id: r.id)?.name, "B")
+        store.remove(id: r.id)
+        XCTAssertTrue(store.automations.isEmpty)
+    }
+
+    func test_setEnabled() {
+        let d = UserDefaults(suiteName: "AutomationStoreTests2")!
+        d.removePersistentDomain(forName: "AutomationStoreTests2")
+        let store = AutomationStore(defaults: d)
+        let r = make("A"); store.upsert(r)
+        store.setEnabled(false, id: r.id)
+        XCTAssertEqual(store.automation(id: r.id)?.enabled, false)
+    }
+}

--- a/macOSBridgeTests/HAPCarbonDioxideTests.swift
+++ b/macOSBridgeTests/HAPCarbonDioxideTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+import HAPCore
+@testable import macOSBridge
+
+final class HAPCarbonDioxideTests: XCTestCase {
+    func test_carbonDioxideSensor_hasDetectedCharacteristic() {
+        let svc = HAPService.carbonDioxideSensor(startIID: 2)
+        XCTAssertEqual(svc.type, .carbonDioxideSensor)
+        XCTAssertEqual(svc.characteristics.count, 1)
+        let ch = svc.characteristics[0]
+        XCTAssertEqual(ch.type, .carbonDioxideDetected)
+        XCTAssertEqual(ch.iid, 2)
+        XCTAssertEqual(ch.value, .uint8(0))
+    }
+
+    func test_carbonDioxide_typeRawValues_matchHomeKit() {
+        XCTAssertEqual(HAPServiceType.carbonDioxideSensor.rawValue, "97")
+        XCTAssertEqual(HAPCharacteristicType.carbonDioxideDetected.rawValue, "92")
+    }
+}

--- a/macOSBridgeTests/VirtualBridgeServiceTests.swift
+++ b/macOSBridgeTests/VirtualBridgeServiceTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+import HAPCore
+import HAPSwift
+import HAPApple
+@testable import macOSBridge
+
+final class VirtualBridgeServiceTests: XCTestCase {
+    func test_detectedIID_locatesDetectedCharacteristic() async {
+        let bridge = HAPBridge(info: HAPCore.AccessoryInfo(
+            name: "T", manufacturer: "I", model: "M", serialNumber: "S", firmwareRevision: "1"))
+        let aid = await bridge.addAccessory(
+            info: HAPCore.AccessoryInfo(name: "Leak", manufacturer: "I", model: "M",
+                                        serialNumber: "L1", firmwareRevision: "1"),
+            services: [VirtualSensorType.leak.makeHAPService(startIID: 2)])
+
+        guard let iid = await VirtualBridgeService.detectedIID(in: bridge, aid: aid, type: .leak) else {
+            return XCTFail("no detected characteristic iid found")
+        }
+        let value = await bridge.readCharacteristic(aid: aid, iid: iid)
+        XCTAssertNotNil(value)
+    }
+}

--- a/macOSBridgeTests/VirtualControlRoutingTests.swift
+++ b/macOSBridgeTests/VirtualControlRoutingTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import macOSBridge
+
+final class VirtualControlRoutingTests: XCTestCase {
+    func test_verb_mapsToBooleanState() {
+        XCTAssertEqual(VirtualControl.boolean(for: .turnOn), true)
+        XCTAssertEqual(VirtualControl.boolean(for: .turnOff), false)
+        XCTAssertEqual(VirtualControl.boolean(for: .setPosition(100)), true)   // "open"
+        XCTAssertEqual(VirtualControl.boolean(for: .setPosition(0)), false)    // "close"
+        XCTAssertNil(VirtualControl.boolean(for: .setBrightness(50)))          // not a binary verb
+    }
+
+    func test_toggle_flipsCurrentState() {
+        XCTAssertEqual(VirtualControl.nextState(forToggleFrom: true), false)
+        XCTAssertEqual(VirtualControl.nextState(forToggleFrom: false), true)
+    }
+}

--- a/macOSBridgeTests/VirtualDeviceStoreTests.swift
+++ b/macOSBridgeTests/VirtualDeviceStoreTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import macOSBridge
+
+final class VirtualDeviceStoreTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var store: VirtualDeviceStore!
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: "VirtualDeviceStoreTests")!
+        defaults.removePersistentDomain(forName: "VirtualDeviceStoreTests")
+        store = VirtualDeviceStore(defaults: defaults)
+    }
+
+    func test_add_assignsKeyAidAndPersists() throws {
+        let d = try store.add(name: "Front Door", type: .contact, role: .door, room: "Hall")
+        XCTAssertEqual(d.key, "front-door")
+        XCTAssertEqual(d.aid, 2)            // first device gets aid 2 (1 is reserved by the bridge)
+        // Reload from the same defaults -> persisted.
+        let store2 = VirtualDeviceStore(defaults: defaults)
+        XCTAssertEqual(store2.devices.count, 1)
+        XCTAssertEqual(store2.devices.first?.name, "Front Door")
+    }
+
+    func test_add_rejectsDuplicateName() throws {
+        _ = try store.add(name: "Front Door", type: .contact, role: .door, room: nil)
+        XCTAssertThrowsError(try store.add(name: "front door", type: .motion, role: nil, room: nil))
+    }
+
+    func test_aids_areUniqueAndStableAcrossRemoval() throws {
+        let a = try store.add(name: "A", type: .contact, role: nil, room: nil)
+        let b = try store.add(name: "B", type: .motion, role: nil, room: nil)
+        XCTAssertNotEqual(a.aid, b.aid)
+        store.remove(id: a.id)
+        let c = try store.add(name: "C", type: .leak, role: nil, room: nil)
+        XCTAssertNotEqual(c.aid, b.aid)    // never reuse a live aid
+    }
+
+    func test_setState_persistsAndReports() throws {
+        let d = try store.add(name: "Leak", type: .leak, role: nil, room: nil)
+        store.setState(id: d.id, on: true)
+        XCTAssertEqual(store.device(id: d.id)?.state, true)
+        XCTAssertEqual(VirtualDeviceStore(defaults: defaults).device(id: d.id)?.state, true)
+    }
+}

--- a/macOSBridgeTests/VirtualDeviceTests.swift
+++ b/macOSBridgeTests/VirtualDeviceTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import macOSBridge
+
+final class VirtualDeviceTests: XCTestCase {
+    func test_slug_fromName() {
+        XCTAssertEqual(VirtualDevice.slug(from: "Front Door"), "front-door")
+        XCTAssertEqual(VirtualDevice.slug(from: "Garage  Motion!"), "garage-motion")
+        XCTAssertEqual(VirtualDevice.slug(from: "  CO2 Alarm  "), "co2-alarm")
+    }
+
+    func test_codable_roundTrip() throws {
+        let d = VirtualDevice(id: UUID(), key: "front-door", name: "Front Door",
+                              type: .contact, role: .door, room: "Hallway",
+                              aid: 2, state: true)
+        let data = try JSONEncoder().encode(d)
+        let back = try JSONDecoder().decode(VirtualDevice.self, from: data)
+        XCTAssertEqual(back, d)
+    }
+
+    func test_allTypes_haveStableRawValues() {
+        // Persisted, so raw values must never change.
+        XCTAssertEqual(VirtualSensorType.allCases.map(\.rawValue).sorted(),
+                       ["carbonDioxide", "carbonMonoxide", "contact", "leak", "motion", "occupancy", "smoke"])
+    }
+}

--- a/macOSBridgeTests/VirtualSensorMappingTests.swift
+++ b/macOSBridgeTests/VirtualSensorMappingTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+import HAPCore
+@testable import macOSBridge
+
+final class VirtualSensorMappingTests: XCTestCase {
+    func test_eachType_mapsToHAPService() {
+        let expected: [VirtualSensorType: HAPServiceType] = [
+            .contact: .contactSensor, .motion: .motionSensor, .occupancy: .occupancySensor,
+            .leak: .leakSensor, .smoke: .smokeSensor,
+            .carbonMonoxide: .carbonMonoxideSensor, .carbonDioxide: .carbonDioxideSensor,
+        ]
+        for t in VirtualSensorType.allCases {
+            let svc = t.makeHAPService(startIID: 2)
+            XCTAssertEqual(svc.type, expected[t], "wrong service for \(t)")
+            XCTAssertEqual(svc.characteristics.count, 1)
+        }
+    }
+
+    func test_homeKitServiceTypeString_matchesServiceTypesConstant() {
+        // Used by the MenuData projection; must match Itsyhome/Shared ServiceTypes.
+        XCTAssertEqual(VirtualSensorType.contact.homeKitServiceType, ServiceTypes.contactSensor)
+        XCTAssertEqual(VirtualSensorType.motion.homeKitServiceType, ServiceTypes.motionSensor)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -13,7 +13,7 @@ packages:
     exactVersion: "137.7151.12"
   hap-swift:
     url: https://github.com/mikeburgh/hap-swift.git
-    branch: macos14
+    revision: 6e62417d61522823552417714b62af89b2e211b3
 
 settings:
   base:

--- a/project.yml
+++ b/project.yml
@@ -11,6 +11,9 @@ packages:
   LiveKitWebRTC:
     url: https://github.com/livekit/webrtc-xcframework.git
     exactVersion: "137.7151.12"
+  hap-swift:
+    url: https://github.com/mikeburgh/hap-swift.git
+    branch: macos14
 
 settings:
   base:
@@ -105,6 +108,10 @@ targets:
         embed: false
       - sdk: CoreLocation.framework
         embed: false
+      - package: hap-swift
+        product: HAPSwift
+      - package: hap-swift
+        product: HAPApple
 
   # Unit tests for macOSBridge
   macOSBridgeTests:
@@ -139,9 +146,19 @@ targets:
       - path: macOSBridge/Settings/PreferencesManager+Shortcuts.swift
       - path: macOSBridge/Settings/PreferencesManager+Icons.swift
       - path: macOSBridge/Settings/PreferencesManager+Networks.swift
+      - path: macOSBridge/Settings/PreferencesManager+VirtualBridge.swift
       - path: Itsyhome/Shared
         buildPhase: sources
       - path: Itsyhome/HomeAssistant
         buildPhase: sources
     dependencies:
       - target: macOSBridge
+      # The test target compiles the macOSBridge sources directly (incl.
+      # HAPBridge/*), which import HAPCore/HAPSwift/HAPApple, so it must link
+      # the hap-swift products too.
+      - package: hap-swift
+        product: HAPSwift
+      - package: hap-swift
+        product: HAPApple
+      - package: hap-swift
+        product: HAPCore


### PR DESCRIPTION
## What this adds

**Virtual HomeKit sensor bridge** - publishes ItsyHome-driven read-only sensors (contact, motion, occupancy, leak, smoke, CO, CO2) to Apple Home over HAP. New **HomeKit Bridge** settings section: enable, setup code + pairing reset, add/edit/remove, room assignment, per-device toggle. Controlled by name via the existing webhook verbs; pairings and identity persist across restarts; sensors surface in the menu via the normal HomeKit read.

**Automations** - new section + engine (Pro): WHEN a HomeKit accessory holds a state FOR a duration THEN set a virtual sensor, with re-pulse. Lets Apple Home automate on conditions HomeKit cannot compute itself (e.g. "door open for 15 min"). Pluggable triggers/conditions/actions.

## Notes
- **hap-swift** forked from ([acumen-dev/hap-swift](https://github.com/acumen-dev/hap-swift), Apache-2.0). I have submitted PR's to move their version down to macos 14 (including mdns-swift), and can switch the packaging back once that lands. 

## Scope
Milestone 1. Follow-ups are additive:(Schedule + Webhook triggers), (control-device / run-scene actions).


