### PR TITLE
feat: configurable webhook bind address

### DIFF
--- a/macOSBridge/Settings/Sections/WebhooksSection.swift
+++ b/macOSBridge/Settings/Sections/WebhooksSection.swift
@@ -13,6 +13,7 @@ class WebhooksSection: SettingsCard {
     private var statusLabel: NSTextField!
     private var addressLabel: NSTextField!
     private var portField: NSTextField!
+    private var bindAddressField: NSTextField!
 
     private let actions: [(action: String, format: String, example: String)] = [
         ("Toggle", "toggle/<Room>/<Device>", "toggle/Office/Spotlights"),
@@ -247,6 +248,32 @@ class WebhooksSection: SettingsCard {
         portRow.addArrangedSubview(portField)
         stack.addArrangedSubview(portRow)
 
+        // Bind address row
+        let bindRow = NSStackView()
+        bindRow.orientation = .horizontal
+        bindRow.spacing = 6
+        bindRow.alignment = .centerY
+
+        let bindTitle = createLabel(String(localized: "settings.webhooks.bind_label", defaultValue: "Bind:", bundle: .macOSBridge), style: .body)
+        bindTitle.translatesAutoresizingMaskIntoConstraints = false
+        bindTitle.widthAnchor.constraint(equalToConstant: labelWidth).isActive = true
+        bindAddressField = NSTextField()
+        bindAddressField.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+        bindAddressField.placeholderString = "All interfaces"
+        bindAddressField.stringValue = WebhookServer.configuredBindAddress ?? ""
+        bindAddressField.translatesAutoresizingMaskIntoConstraints = false
+        bindAddressField.widthAnchor.constraint(equalToConstant: 140).isActive = true
+        bindAddressField.target = self
+        bindAddressField.action = #selector(bindAddressChanged)
+
+        bindRow.addArrangedSubview(bindTitle)
+        bindRow.addArrangedSubview(bindAddressField)
+        stack.addArrangedSubview(bindRow)
+
+        let restartHint = createLabel("Address/port changes apply on next app launch.", style: .caption)
+        restartHint.textColor = .tertiaryLabelColor
+        stack.addArrangedSubview(restartHint)
+
         return stack
     }
 
@@ -426,6 +453,22 @@ class WebhooksSection: SettingsCard {
                 WebhookServer.shared.start()
             }
         }
+    }
+
+    @objc private func bindAddressChanged(_ sender: NSTextField) {
+        let trimmed = sender.stringValue.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty {
+            UserDefaults.standard.removeObject(forKey: WebhookServer.bindAddressKey)
+            sender.stringValue = ""
+            return
+        }
+        guard WebhookServer.isValidIPAddress(trimmed) else {
+            // Reject invalid input; restore last valid value.
+            sender.stringValue = WebhookServer.configuredBindAddress ?? ""
+            return
+        }
+        UserDefaults.standard.set(trimmed, forKey: WebhookServer.bindAddressKey)
+        sender.stringValue = trimmed
     }
 
     @objc private func statusDidChange() {

--- a/macOSBridge/Webhook/WebhookServer.swift
+++ b/macOSBridge/Webhook/WebhookServer.swift
@@ -10,10 +10,11 @@ import Network
 
 final class WebhookServer {
 
-    static let shared = WebhookServer(port: configuredPort)
+    static let shared = WebhookServer(port: configuredPort, bindAddress: configuredBindAddress)
 
     static let defaultPort: UInt16 = 8423
     static let portKey = "webhookServerPort"
+    static let bindAddressKey = "webhookServerBindAddress"
     static let statusChangedNotification = Notification.Name("webhookStatusChangedNotification")
     static let enabledKey = "webhookServerEnabled"
 
@@ -22,7 +23,27 @@ final class WebhookServer {
         return stored > 0 ? UInt16(stored) : defaultPort
     }
 
+    /// Configured bind address. Empty/unset means bind all interfaces
+    /// (default, unchanged behavior). Returns nil when unset, empty, or
+    /// not a valid IP literal so the server falls back to all-interfaces.
+    static var configuredBindAddress: String? {
+        guard let raw = UserDefaults.standard.string(forKey: bindAddressKey) else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, isValidIPAddress(trimmed) else { return nil }
+        return trimmed
+    }
+
+    /// Validate an IPv4 or IPv6 literal using inet_pton (no DNS).
+    static func isValidIPAddress(_ string: String) -> Bool {
+        var v4 = in_addr()
+        if string.withCString({ inet_pton(AF_INET, $0, &v4) }) == 1 { return true }
+        var v6 = in6_addr()
+        if string.withCString({ inet_pton(AF_INET6, $0, &v6) }) == 1 { return true }
+        return false
+    }
+
     let port: UInt16
+    let bindAddress: String?
 
     enum State: Equatable {
         case stopped
@@ -46,8 +67,9 @@ final class WebhookServer {
     var lastPublishedValues: [String: String] = [:]
     var heartbeatTimer: DispatchSourceTimer?
 
-    init(port: UInt16) {
+    init(port: UInt16, bindAddress: String? = nil) {
         self.port = port
+        self.bindAddress = bindAddress
     }
 
     // MARK: - Configuration
@@ -70,6 +92,11 @@ final class WebhookServer {
         do {
             let params = NWParameters.tcp
             params.allowLocalEndpointReuse = true
+            if let addr = bindAddress {
+                params.requiredLocalEndpoint = NWEndpoint.hostPort(
+                    host: NWEndpoint.Host(addr),
+                    port: NWEndpoint.Port(rawValue: port)!)
+            }
             let listener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: port)!)
             self.listener = listener
 

--- a/macOSBridgeTests/WebhookTests/WebhookServerTests.swift
+++ b/macOSBridgeTests/WebhookTests/WebhookServerTests.swift
@@ -352,6 +352,58 @@ final class WebhookServerTests: XCTestCase {
         XCTAssertEqual(WebhookServer.configuredPort, 8423)
     }
 
+    // MARK: - Bind address configuration tests
+
+    func testDefaultBindAddressIsNil() {
+        let original = UserDefaults.standard.object(forKey: WebhookServer.bindAddressKey)
+        defer { restoreBindAddress(original) }
+
+        UserDefaults.standard.removeObject(forKey: WebhookServer.bindAddressKey)
+        XCTAssertNil(WebhookServer.configuredBindAddress)
+    }
+
+    func testValidIPv4BindAddressIsReturned() {
+        let original = UserDefaults.standard.object(forKey: WebhookServer.bindAddressKey)
+        defer { restoreBindAddress(original) }
+
+        UserDefaults.standard.set("100.64.0.1", forKey: WebhookServer.bindAddressKey)
+        XCTAssertEqual(WebhookServer.configuredBindAddress, "100.64.0.1")
+    }
+
+    func testInvalidBindAddressFallsBackToNil() {
+        let original = UserDefaults.standard.object(forKey: WebhookServer.bindAddressKey)
+        defer { restoreBindAddress(original) }
+
+        UserDefaults.standard.set("not-an-ip", forKey: WebhookServer.bindAddressKey)
+        XCTAssertNil(WebhookServer.configuredBindAddress)
+    }
+
+    func testIPv6BindAddressIsAccepted() {
+        let original = UserDefaults.standard.object(forKey: WebhookServer.bindAddressKey)
+        defer { restoreBindAddress(original) }
+
+        UserDefaults.standard.set("::1", forKey: WebhookServer.bindAddressKey)
+        XCTAssertEqual(WebhookServer.configuredBindAddress, "::1")
+    }
+
+    func testIsValidIPAddress() {
+        XCTAssertTrue(WebhookServer.isValidIPAddress("127.0.0.1"))
+        XCTAssertTrue(WebhookServer.isValidIPAddress("100.64.0.1"))
+        XCTAssertTrue(WebhookServer.isValidIPAddress("::1"))
+        XCTAssertTrue(WebhookServer.isValidIPAddress("fe80::1"))
+        XCTAssertFalse(WebhookServer.isValidIPAddress(""))
+        XCTAssertFalse(WebhookServer.isValidIPAddress("999.999.999.999"))
+        XCTAssertFalse(WebhookServer.isValidIPAddress("hello"))
+        XCTAssertFalse(WebhookServer.isValidIPAddress("256.1.1.1"))
+    }
+
+    func testServerWithBindAddressInitializes() {
+        let boundServer = WebhookServer(port: 18424, bindAddress: "127.0.0.1")
+        boundServer.configure(actionEngine: engine)
+
+        XCTAssertEqual(boundServer.state, .stopped)
+    }
+
     // MARK: - IP address test
 
     func testLocalIPAddressReturnsNonNil() {
@@ -496,6 +548,14 @@ final class WebhookServerTests: XCTestCase {
 
         wait(for: [responseExpectation], timeout: 10)
         return httpResponse
+    }
+
+    private func restoreBindAddress(_ original: Any?) {
+        if let original {
+            UserDefaults.standard.set(original, forKey: WebhookServer.bindAddressKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: WebhookServer.bindAddressKey)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Lets the webhook HTTP server bind to a specific local IP address instead of always binding all interfaces. Empty/unset keeps today's behavior (bind all interfaces), so the default is unchanged.

## Why this matters (#126)
The webhook server currently binds on all interfaces using only a configured port. The request in #126 is to choose which local IP the server binds to - for example a Tailscale interface address - so the endpoint is reachable over a private mesh network without opening router port-forwarding.

## Changes
- `WebhookServer.swift`: added `bindAddressKey` / `configuredBindAddress`, mirroring the existing `portKey` / `configuredPort` pattern. The address is stored in `UserDefaults`; empty/unset returns `nil` (bind all interfaces). An invalid stored value (validated with `inet_pton`, no DNS) also returns `nil`, so a typo can never brick the server. When a valid address is configured, `start()` sets `NWParameters.requiredLocalEndpoint` to `NWEndpoint.hostPort(host:port:)` before constructing the `NWListener`; otherwise the listener is created exactly as before.
- `WebhooksSection.swift`: added a "Bind:" input row modeled on the existing port row, plus a restart-required hint. Input is validated before persisting; an invalid entry is rejected and the field reverts to the last valid value.
- `WebhookServerTests.swift`: added unit tests for default-nil, valid IPv4, IPv6, invalid-fallback-to-nil, the `isValidIPAddress` validator, and constructing a server with a bind address.

## Testing
- Added XCTest cases in `macOSBridgeTests/WebhookTests/WebhookServerTests.swift` covering the default (all-interfaces) regression, valid IPv4/IPv6 acceptance, and invalid-input fallback.
- Both edited source files pass `swiftc -parse`. Verified `NWEndpoint.Host("127.0.0.1")` resolves to the `.ipv4` case (not a DNS name), confirming the address is treated as a literal.

Fixes #126

AI was used for assistance.
