### PR TITLE
Sensor History

### DIFF
--- a/Itsyhome.xcodeproj/project.pbxproj
+++ b/Itsyhome.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		05F500B5C1682C89F59B2CCB /* ph.train-simple.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 603A597C3F500BE7431EDCB2 /* ph.train-simple.fill.svg */; };
 		0614CAD3EBA19625AF0ACB5A /* ph.sign-in.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 5568403E2983DD8201F73DB2 /* ph.sign-in.fill.svg */; };
 		061ED3A7F03E627F6D6D551D /* ph.number-square-four.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = DB7046C1BD0F9267A1220F69 /* ph.number-square-four.fill.svg */; };
+		0636DB50383AE753F38C6DF2 /* SensorHistoryRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09ADABAA9D3B404634F73F96 /* SensorHistoryRegistry.swift */; };
 		063B4DE9C9A7887E25154630 /* ph.sliders-horizontal.svg in Resources */ = {isa = PBXBuildFile; fileRef = D824278C9FE2993414C27311 /* ph.sliders-horizontal.svg */; };
 		06563D2DCDD0D3B3AB999B7E /* AutomationDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD708B8E691F4265A280899F /* AutomationDraft.swift */; };
 		069B3B0D33FB7434CEB1B2CE /* ph.chalkboard-simple.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8EF48C8D69495899691F3690 /* ph.chalkboard-simple.fill.svg */; };
@@ -147,6 +148,7 @@
 		0A67A85380E07561A8487064 /* ph.currency-eur.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 79AA9D8EB5B8E76C5E036C6B /* ph.currency-eur.fill.svg */; };
 		0A6A1D31346AB6ACCF3C4B45 /* ph.bluetooth-connected.svg in Resources */ = {isa = PBXBuildFile; fileRef = 79796F2259A57D9DB246F703 /* ph.bluetooth-connected.svg */; };
 		0AA2AEB906362557627BDB4D /* ph.chat-circle.svg in Resources */ = {isa = PBXBuildFile; fileRef = F3329433419F10F187BCB1F2 /* ph.chat-circle.svg */; };
+		0AAAAFA5D0871170CA5747A3 /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE72D4A22DF6213D91028AC5 /* SparklineView.swift */; };
 		0ACC9D9B0FEE4A45D5F86789 /* ph.flashlight.svg in Resources */ = {isa = PBXBuildFile; fileRef = ADC604C6E1B6DA41B04FB10D /* ph.flashlight.svg */; };
 		0AE9FFB43AE2BAEE112BEE83 /* HomeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 748347D84F0BDF92DA4DE1E4 /* HomeKit.framework */; };
 		0AEF21EA27F121C49DB4CB3F /* ph.rows.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = EBA530990DBEFC7100800B9E /* ph.rows.fill.svg */; };
@@ -207,6 +209,7 @@
 		0EDA6B68175CD5E7D47D9A60 /* ph.number-square-nine.svg in Resources */ = {isa = PBXBuildFile; fileRef = 25DBC6D4B177686E4D66A637 /* ph.number-square-nine.svg */; };
 		0EDCDCED2A4415D86B823250 /* ph.armchair.svg in Resources */ = {isa = PBXBuildFile; fileRef = C0AC5DB1D358EB4992692EFE /* ph.armchair.svg */; };
 		0EE3EB8ACA1A931FC9816CE7 /* ph.file-audio.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 85BE489E455C5493A49D4B46 /* ph.file-audio.fill.svg */; };
+		0EEB4EAAB99AFB8A1600F787 /* SensorHistoryRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90D09DB529889E99ABBABEA /* SensorHistoryRegistryTests.swift */; };
 		0F1B47C33922875964D21B06 /* HomeAssistantPlatform+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C20456460E3E778B6B9369 /* HomeAssistantPlatform+Delegate.swift */; };
 		0F1EE16E5ABB2942DA16CFF7 /* ph.dot-outline.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = AA25AA3737C8C77056DFE3F7 /* ph.dot-outline.fill.svg */; };
 		0F21CA52FC71932775FE0147 /* ph.push-pin-slash.svg in Resources */ = {isa = PBXBuildFile; fileRef = 64F0F0FE383F74466EC70A65 /* ph.push-pin-slash.svg */; };
@@ -313,6 +316,7 @@
 		16F6E1F8BD6167C79C46BCF8 /* ph.heart-straight-break.svg in Resources */ = {isa = PBXBuildFile; fileRef = 5E79A5927FF78131BD4BD1E3 /* ph.heart-straight-break.svg */; };
 		16F6F6D1B24EDA16CEA8FD2D /* ph.shirt-folded.svg in Resources */ = {isa = PBXBuildFile; fileRef = 064F535D2F0F3C1A4BAEDB1D /* ph.shirt-folded.svg */; };
 		170843AF0144D376A8F3D26F /* vacation.png in Resources */ = {isa = PBXBuildFile; fileRef = 081A3669F1F1284F758F208E /* vacation.png */; };
+		1719567A8F1DFE7989B38526 /* HistoryRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200F746C5505FF0EBFE205DA /* HistoryRenderingTests.swift */; };
 		171D8A492CC9B203C7C5C733 /* ph.crosshair-simple.svg in Resources */ = {isa = PBXBuildFile; fileRef = 63AB7A9D7D36022E01DD7C5A /* ph.crosshair-simple.svg */; };
 		171DBD4F602AA2C0E8E916E0 /* ph.file-svg.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 30DEA7612C6A4DA055BC1B7E /* ph.file-svg.fill.svg */; };
 		1728C03ACDE7405D842A0392 /* ph.markdown-logo.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 28B8B4498B09C660ADA3129D /* ph.markdown-logo.fill.svg */; };
@@ -504,6 +508,7 @@
 		244C20B10F18B945A6B149B1 /* ph.windmill.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 65A95A80E57D00146F4D9320 /* ph.windmill.fill.svg */; };
 		2452DBB79A0EA0759948E493 /* CameraViewController+Streaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914A41E0AA9D87F86AA5935F /* CameraViewController+Streaming.swift */; };
 		245F46039EF5E759D6399DFE /* ph.drop-half.svg in Resources */ = {isa = PBXBuildFile; fileRef = F6F9B5A4850D11E82A7EAEB2 /* ph.drop-half.svg */; };
+		247E9D98CA3892EFEFD47054 /* HistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FE57D3362F8C7CFF86B93ED /* HistoryStore.swift */; };
 		2481281292AB2F8F43A81EF7 /* ph.threads-logo.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 16D323E5A6F4AC2E44C95240 /* ph.threads-logo.fill.svg */; };
 		248404BF4536DEE8D32F298E /* ph.battery-vertical-medium.svg in Resources */ = {isa = PBXBuildFile; fileRef = B7BEE8A38DFC596D9C35FFE2 /* ph.battery-vertical-medium.svg */; };
 		249A83F97EDE11F62CCF0B3F /* ph.microsoft-word-logo.svg in Resources */ = {isa = PBXBuildFile; fileRef = C43366CC22CAC061E782D102 /* ph.microsoft-word-logo.svg */; };
@@ -559,6 +564,7 @@
 		2896F5D0D0F69605587009A1 /* ph.music-note.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = C57E13734C4516932FD35169 /* ph.music-note.fill.svg */; };
 		28A0FE682876CACEFB2C906E /* ph.syringe.svg in Resources */ = {isa = PBXBuildFile; fileRef = 5FED49DD77A28B568D89E54D /* ph.syringe.svg */; };
 		28A43FD6F2622B9CF35BC2C0 /* LockMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4374C26148C6FEAAFD207413 /* LockMenuItem.swift */; };
+		28A5446CBC8A41EEBA4D7EEF /* HistoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA453EE89AE0A4F2C628EDE /* HistoryDetailView.swift */; };
 		28B5F7BA9021D479977F312E /* AccessoriesSettingsView+TableDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69710E65E70E915FAA68786 /* AccessoriesSettingsView+TableDelegate.swift */; };
 		28D5B03C46A390CCB597D196 /* ph.cigarette.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = B75441BC77F9729DF7FD95D3 /* ph.cigarette.fill.svg */; };
 		28E0C6D49BCA699CAE13D38A /* ph.chat-centered.svg in Resources */ = {isa = PBXBuildFile; fileRef = AF607FEE12E046B169AB79FD /* ph.chat-centered.svg */; };
@@ -1315,6 +1321,7 @@
 		6281DC72AA7E98165A7C0CD3 /* ph.anchor-simple.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 62D0FDDF3BA32471134714BA /* ph.anchor-simple.fill.svg */; };
 		628CB7EDBA3051C9FB3B72B4 /* ph.file-tsx.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6797259A3C2D7AB18DE69C0A /* ph.file-tsx.fill.svg */; };
 		629F924EFA70F0C7A48C6026 /* ph.minus-square.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = B29E258AD1A8976F44C1691A /* ph.minus-square.fill.svg */; };
+		62D93B12E6007F9F0325F6D8 /* HistoryRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62ACB370A54D4ED820B221D /* HistoryRendering.swift */; };
 		62DFBB5567AA1428BFAC6AD4 /* ph.dots-six.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 379FEFD78B712584F68A12CA /* ph.dots-six.fill.svg */; };
 		6301137D2D80827FBCDC3B71 /* ph.calendar-heart.svg in Resources */ = {isa = PBXBuildFile; fileRef = D0C3F832E115624257DC038A /* ph.calendar-heart.svg */; };
 		63075A1DB8EFEA082A528955 /* ph.asclepius.svg in Resources */ = {isa = PBXBuildFile; fileRef = E13D6BD25EE8718C6CA9DA7B /* ph.asclepius.svg */; };
@@ -1392,6 +1399,7 @@
 		67F82E96858514BCDD7CCCB6 /* ph.prohibit-inset.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 9D619A164C9E7112B13D46D3 /* ph.prohibit-inset.fill.svg */; };
 		67F977FD2A020855178DB8F7 /* ph.flying-saucer.svg in Resources */ = {isa = PBXBuildFile; fileRef = 4AA7A9281B4FE42F6C341300 /* ph.flying-saucer.svg */; };
 		680D90D25922D1D80083CFC7 /* SecuritySystemMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBD57CCBF703A5861D8AEFB0 /* SecuritySystemMenuItem.swift */; };
+		681407D7E46EEF096BA7B96B /* HistoryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9C5E2680E74B1F834B9DC7 /* HistoryStoreTests.swift */; };
 		6870C2FD692EE67128A8ED32 /* ph.alarm.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 614CA2F4C95763A913FE8D1C /* ph.alarm.fill.svg */; };
 		687969352D1283E37F80BB9B /* ph.git-diff.svg in Resources */ = {isa = PBXBuildFile; fileRef = D685D3D51513F75866E3E022 /* ph.git-diff.svg */; };
 		6898E8C9153768433C3EC150 /* ph.x.svg in Resources */ = {isa = PBXBuildFile; fileRef = B8D97A3C93B4AE321E247137 /* ph.x.svg */; };
@@ -1954,6 +1962,7 @@
 		9117EE570E060274A3768725 /* ph.notepad.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8843A5A186CC09F325E2B00D /* ph.notepad.svg */; };
 		91182B77DC42B28CE2611B29 /* ph.share.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 1EC56D05BF8233BFBE5B42FF /* ph.share.fill.svg */; };
 		91457244D180B4A8BF90E774 /* ph.tag-chevron.svg in Resources */ = {isa = PBXBuildFile; fileRef = 9F0E6EAFF676E6210169EAA2 /* ph.tag-chevron.svg */; };
+		9148D96320F39AE59D52ECD1 /* HistoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B72FC474D5713BAB0A5D326 /* HistoryStorage.swift */; };
 		9152D628D15146FC06FE6B70 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3A3EB6D0DE7E9C0DE57ABAF /* Protocols.swift */; };
 		915A1875DE051AF467602030 /* ph.phone-pause.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 5BAE9679678B06985FB8E618 /* ph.phone-pause.fill.svg */; };
 		915CE5514CD63CD89D786745 /* ph.gender-female.svg in Resources */ = {isa = PBXBuildFile; fileRef = B281A85137E51919DBAC9A2C /* ph.gender-female.svg */; };
@@ -2089,7 +2098,9 @@
 		9B37C6D35C23D5EA83F25141 /* ph.radioactive.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6A2D8FAEBEC0054ADF62C7F6 /* ph.radioactive.fill.svg */; };
 		9B3E0F9262F5A1FC61AE6585 /* ph.file-css.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = A4FD8A1992AF753FAC46D0F3 /* ph.file-css.fill.svg */; };
 		9B4772FBE87FC9A68E5C6875 /* ph.chat.svg in Resources */ = {isa = PBXBuildFile; fileRef = 77456FB83169C0C1A6D1EFCA /* ph.chat.svg */; };
+		9B48C787BC0C2C46FDDAAA17 /* SensorHistoryRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09ADABAA9D3B404634F73F96 /* SensorHistoryRegistry.swift */; };
 		9B55E502BE8265C5CD70C0FB /* CloudSyncTranslatorCameraTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78063132727D342A2B432E1C /* CloudSyncTranslatorCameraTests.swift */; };
+		9B78CFFBC5DBDF3E3B56DB16 /* HistorySample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AAE4E565B030A7EE3FD6202 /* HistorySample.swift */; };
 		9BB56AC50321A8FEE401049B /* ph.arrows-horizontal.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6B35838D3780B375A1C3CB9A /* ph.arrows-horizontal.fill.svg */; };
 		9BC76F2C00E1659DE62D3D19 /* ph.cricket.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6D91805064587FCC64C47E8C /* ph.cricket.fill.svg */; };
 		9BC79583332536258C6D247B /* ph.currency-kzt.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = F3195CD121AB47D877432EA5 /* ph.currency-kzt.fill.svg */; };
@@ -2183,6 +2194,7 @@
 		A24253818779D0503D9DFC67 /* ph.battery-vertical-high.svg in Resources */ = {isa = PBXBuildFile; fileRef = 648A8CFCD9101C7F63A97C92 /* ph.battery-vertical-high.svg */; };
 		A259F3C58691CEC547245289 /* ph.presentation.svg in Resources */ = {isa = PBXBuildFile; fileRef = F2509E4EE21742C96AA95ED3 /* ph.presentation.svg */; };
 		A278F315F9E3096376CF45DF /* ph.ping-pong.svg in Resources */ = {isa = PBXBuildFile; fileRef = 7DA80C9075F3B4070C5EC33E /* ph.ping-pong.svg */; };
+		A27B2CC098B97F1A21B4EBD5 /* HistoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B72FC474D5713BAB0A5D326 /* HistoryStorage.swift */; };
 		A2A88E6DE7466033485DC6BE /* ph.asterisk-simple.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 1A182E95832BF566EFB77D65 /* ph.asterisk-simple.fill.svg */; };
 		A2C41C6A74C2F28C9CAC7A89 /* ph.smiley-nervous.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 59C25225C857210CDB3335E2 /* ph.smiley-nervous.fill.svg */; };
 		A2D59F6803626343344E5E50 /* ph.currency-inr.svg in Resources */ = {isa = PBXBuildFile; fileRef = AE17BCE6A76AA7F403F92C7C /* ph.currency-inr.svg */; };
@@ -2338,6 +2350,7 @@
 		ADAEEFD46A7871933BAB1707 /* ph.bookmark-simple.svg in Resources */ = {isa = PBXBuildFile; fileRef = E12EC3DAAADE0129F61022A0 /* ph.bookmark-simple.svg */; };
 		ADD30900D5713D5480E1C742 /* ph.mouse-middle-click.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 2EE86F757DD4A95E7093C3D3 /* ph.mouse-middle-click.fill.svg */; };
 		ADE1CDE801F9C430F7CBE9E8 /* ph.corners-in.svg in Resources */ = {isa = PBXBuildFile; fileRef = 9FD883853EDDDE051F00E7A7 /* ph.corners-in.svg */; };
+		AE045398CB246AA83BB172EB /* HistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FE57D3362F8C7CFF86B93ED /* HistoryStore.swift */; };
 		AE127D706AEDFC474935044E /* ph.user.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 5593C8AB45E7C79BE848CAF3 /* ph.user.fill.svg */; };
 		AE19BAB4863F8434226C5BAC /* ph.list-heart.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 2C49E4DF504E9FD82B11F1A7 /* ph.list-heart.fill.svg */; };
 		AE23AB93C48F0BC5BA6627C9 /* ph.link-break.svg in Resources */ = {isa = PBXBuildFile; fileRef = 469E27FB571272C1EDB81BB8 /* ph.link-break.svg */; };
@@ -2478,6 +2491,7 @@
 		B81FB504399AF2EF522FF36B /* ph.arrow-square-out.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6CF975DA8B730265512A03FE /* ph.arrow-square-out.svg */; };
 		B85116FDB39B3492F5F7B9F8 /* ph.selection-foreground.svg in Resources */ = {isa = PBXBuildFile; fileRef = C458D9580BF764B43E936333 /* ph.selection-foreground.svg */; };
 		B8571F7697B1DD385E1724E8 /* ph.file-cloud.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = F0C3AAE2E84FFDAEED525CE7 /* ph.file-cloud.fill.svg */; };
+		B877B029F514836C7645B564 /* HistoryRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62ACB370A54D4ED820B221D /* HistoryRendering.swift */; };
 		B884D90C7F075400509E75CA /* VirtualDeviceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B87FA3FF077C5FAC1C7D0DC /* VirtualDeviceStore.swift */; };
 		B8943C6757DEBB63CEC81BC3 /* SecurityIcons in Resources */ = {isa = PBXBuildFile; fileRef = 38A3F8628F6A8DE017FA09F5 /* SecurityIcons */; };
 		B8A535AD4BA43FE47DC71C60 /* ph.align-bottom.svg in Resources */ = {isa = PBXBuildFile; fileRef = 520E2FE57C9B5311588F2C0E /* ph.align-bottom.svg */; };
@@ -2511,6 +2525,7 @@
 		BA4DBA5C182ECA7735B6262B /* ph.exclude.svg in Resources */ = {isa = PBXBuildFile; fileRef = 03D44CE141827A77B422DC19 /* ph.exclude.svg */; };
 		BA71460AC6CD497D32E67864 /* ph.arrow-circle-up.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8F92DC05A15E1704A8E3FA94 /* ph.arrow-circle-up.svg */; };
 		BA75A6D4B5ACE6E6DC7B069E /* ph.sticker.svg in Resources */ = {isa = PBXBuildFile; fileRef = 244C12351C650F4F9C52479A /* ph.sticker.svg */; };
+		BA8CB496468C7A6146F2F2B5 /* HistoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA453EE89AE0A4F2C628EDE /* HistoryDetailView.swift */; };
 		BAA3017E1CF466FBAB0F23BB /* ph.orange-slice.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 85CEE1B3554EDFCE49564948 /* ph.orange-slice.fill.svg */; };
 		BAD5E17565044B572716B2CE /* ph.heart.svg in Resources */ = {isa = PBXBuildFile; fileRef = AC170F51E60AEAFE99A8A023 /* ph.heart.svg */; };
 		BAD6F75B765FC3825700E0FA /* ph.bounding-box.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = F1057B6868245E716D10F681 /* ph.bounding-box.fill.svg */; };
@@ -2557,6 +2572,7 @@
 		BE1C57BE5421AF6007A59729 /* PlatformManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F436EEE369F37FD883DE472B /* PlatformManagerTests.swift */; };
 		BE40C5EEB9EE98AEEB42C30A /* ph.shopping-cart.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 504158B5A668BD82F24D2FB1 /* ph.shopping-cart.fill.svg */; };
 		BE54536A79551150AE929CBD /* ph.phone-incoming.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8BF909776E8F5488F17D4F15 /* ph.phone-incoming.fill.svg */; };
+		BE5CF641403A524028763065 /* HistorySampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D6ABCF7625E6ECE9BA92AC /* HistorySampleTests.swift */; };
 		BE64D5066BF8D36B609D6C0F /* ph.dot.svg in Resources */ = {isa = PBXBuildFile; fileRef = 4AFAEA8512A9BF809B3B1261 /* ph.dot.svg */; };
 		BE65FEC683AA9DA39D6141A0 /* ph.credit-card.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 63C5CE1E1A88B03A4FD8020B /* ph.credit-card.fill.svg */; };
 		BE7EE8B24CBC96E586681210 /* HomeKitManager+Commands.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF2D6AE841E9309235D15BF /* HomeKitManager+Commands.swift */; };
@@ -2766,6 +2782,7 @@
 		CD976E823C73A677B0744454 /* ph.faders.svg in Resources */ = {isa = PBXBuildFile; fileRef = B9FE66A5CC4DBCC4B9CAF85A /* ph.faders.svg */; };
 		CD9CC7D9F4C6F66CB4098F96 /* ModernSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA517D9CAF4A470166D8C402 /* ModernSlider.swift */; };
 		CDD3DB573C521E9BE5929362 /* ph.television-simple.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 74C0D23C3FC332C2D661F712 /* ph.television-simple.fill.svg */; };
+		CE088C9A6B3A8414E199882F /* HistorySample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AAE4E565B030A7EE3FD6202 /* HistorySample.swift */; };
 		CE26DF4CE43F82730D86A588 /* ph.arrow-fat-left.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 07E11AAD587D6EB4B8126024 /* ph.arrow-fat-left.fill.svg */; };
 		CE34D18FE10D19DD7FA60406 /* ph.monitor.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8594093E2E1BBCCAD9FACF50 /* ph.monitor.svg */; };
 		CE4C6F430FA38ECB6E436407 /* ph.checks.svg in Resources */ = {isa = PBXBuildFile; fileRef = E753FE83E66C60FD3D392DBE /* ph.checks.svg */; };
@@ -2898,6 +2915,7 @@
 		D788D031898B86DD6AEE60C2 /* ph.car.svg in Resources */ = {isa = PBXBuildFile; fileRef = 42588FCD43EA1C6EB035FA03 /* ph.car.svg */; };
 		D78E07D3470FB15AAFEFA062 /* ph.plant.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = 553F89137CE68D105289058B /* ph.plant.fill.svg */; };
 		D7D03649E47A218839BB5CBA /* ph.cylinder.svg in Resources */ = {isa = PBXBuildFile; fileRef = F1E6CFAB2FE9AC68F30A32CD /* ph.cylinder.svg */; };
+		D7D3DE6DFE4616B3A5DDA2B6 /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE72D4A22DF6213D91028AC5 /* SparklineView.swift */; };
 		D7DAD84FEA996F94F03E66FE /* ph.trademark-registered.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = EA19630F07C030B7C2627188 /* ph.trademark-registered.fill.svg */; };
 		D7DF9BE8F74B2BB7ACBB440F /* ph.coda-logo.svg in Resources */ = {isa = PBXBuildFile; fileRef = CDA2575F6AB215AABCD5DD88 /* ph.coda-logo.svg */; };
 		D7E930F66ACE5DAE6E4B2594 /* ph.chat-centered-text.svg in Resources */ = {isa = PBXBuildFile; fileRef = DC8046933512FFF7FEEDB453 /* ph.chat-centered-text.svg */; };
@@ -3246,6 +3264,7 @@
 		F540B9C61AA1F32587403CBE /* ph.briefcase.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = A5512355E0EB1F8E45EE468D /* ph.briefcase.fill.svg */; };
 		F54448F96801FD6EF0F2FF0E /* ph.pencil-slash.fill.svg in Resources */ = {isa = PBXBuildFile; fileRef = D7323EB893DEDEDB08EAE992 /* ph.pencil-slash.fill.svg */; };
 		F548A2D77D0E41BBA7231FF1 /* ph.file-dashed.svg in Resources */ = {isa = PBXBuildFile; fileRef = 7AF67AF0BA20D69614107EA1 /* ph.file-dashed.svg */; };
+		F54D0518360AA3CD59E15C50 /* TestServiceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBF2A031B29CA8359771D589 /* TestServiceFactory.swift */; };
 		F54F441C193CE1D7BBA80DBA /* ph.hand-deposit.svg in Resources */ = {isa = PBXBuildFile; fileRef = 7F377EE93375ADB73814FBF3 /* ph.hand-deposit.svg */; };
 		F5788E4F1C327C1C9EF63659 /* ph.chat-centered-slash.svg in Resources */ = {isa = PBXBuildFile; fileRef = CF9FEB44C6CFA79B56F0EE8C /* ph.chat-centered-slash.svg */; };
 		F57D298C44AA0673E805EF46 /* ph.toolbox.svg in Resources */ = {isa = PBXBuildFile; fileRef = 28E094175CA3DD813F89AB85 /* ph.toolbox.svg */; };
@@ -3551,6 +3570,7 @@
 		092427C766DB5E2575471E6F /* ph.arrow-u-right-up.fill.svg */ = {isa = PBXFileReference; path = "ph.arrow-u-right-up.fill.svg"; sourceTree = "<group>"; };
 		094DADB10C0FF4FA5BB4984A /* ph.speedometer.svg */ = {isa = PBXFileReference; path = ph.speedometer.svg; sourceTree = "<group>"; };
 		095948CBBFAF2B045AE43F81 /* ph.cube-transparent.fill.svg */ = {isa = PBXFileReference; path = "ph.cube-transparent.fill.svg"; sourceTree = "<group>"; };
+		09ADABAA9D3B404634F73F96 /* SensorHistoryRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorHistoryRegistry.swift; sourceTree = "<group>"; };
 		09E31A9D7B39D22689A593E1 /* ph.arrow-elbow-left.svg */ = {isa = PBXFileReference; path = "ph.arrow-elbow-left.svg"; sourceTree = "<group>"; };
 		09F07985A9E3806AA127F3BE /* ph.hand-heart.svg */ = {isa = PBXFileReference; path = "ph.hand-heart.svg"; sourceTree = "<group>"; };
 		0A1193552A4D0744C36BF67F /* ph.link-simple.svg */ = {isa = PBXFileReference; path = "ph.link-simple.svg"; sourceTree = "<group>"; };
@@ -3565,6 +3585,7 @@
 		0ADB856CCFC8B986EFC3D154 /* ph.file-c-sharp.svg */ = {isa = PBXFileReference; path = "ph.file-c-sharp.svg"; sourceTree = "<group>"; };
 		0B1CD1FC99663A2930E9BE4B /* ph.user.svg */ = {isa = PBXFileReference; path = ph.user.svg; sourceTree = "<group>"; };
 		0B575A962A4153327B71E9E3 /* ph.radioactive.svg */ = {isa = PBXFileReference; path = ph.radioactive.svg; sourceTree = "<group>"; };
+		0B72FC474D5713BAB0A5D326 /* HistoryStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryStorage.swift; sourceTree = "<group>"; };
 		0B9722C7672919E734E2041D /* ph.battery-warning.fill.svg */ = {isa = PBXFileReference; path = "ph.battery-warning.fill.svg"; sourceTree = "<group>"; };
 		0BA477FE9757AA8E1F93F630 /* ph.arrow-elbow-up-left.svg */ = {isa = PBXFileReference; path = "ph.arrow-elbow-up-left.svg"; sourceTree = "<group>"; };
 		0BE5A45A1729514B7B30AAFB /* ph.wheelchair-motion.svg */ = {isa = PBXFileReference; path = "ph.wheelchair-motion.svg"; sourceTree = "<group>"; };
@@ -3772,6 +3793,7 @@
 		1C71B0D0D0EC3325800CEEC8 /* ph.cactus.fill.svg */ = {isa = PBXFileReference; path = ph.cactus.fill.svg; sourceTree = "<group>"; };
 		1CA1A4DBD1B40C2FAF1CEF86 /* ph.stool.fill.svg */ = {isa = PBXFileReference; path = ph.stool.fill.svg; sourceTree = "<group>"; };
 		1CA3DFEFAE86F9A01F26630C /* ph.letter-circle-v.svg */ = {isa = PBXFileReference; path = "ph.letter-circle-v.svg"; sourceTree = "<group>"; };
+		1CA453EE89AE0A4F2C628EDE /* HistoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDetailView.swift; sourceTree = "<group>"; };
 		1CBB280138C89635A7AF3A8C /* ph.git-branch.svg */ = {isa = PBXFileReference; path = "ph.git-branch.svg"; sourceTree = "<group>"; };
 		1CBFB454ADACBBA91DE70704 /* ph.users-four.fill.svg */ = {isa = PBXFileReference; path = "ph.users-four.fill.svg"; sourceTree = "<group>"; };
 		1CC34B6316986A1585D00861 /* ph.chats-teardrop.fill.svg */ = {isa = PBXFileReference; path = "ph.chats-teardrop.fill.svg"; sourceTree = "<group>"; };
@@ -3814,6 +3836,7 @@
 		1FAE8016C0A912D789F584B7 /* ph.tractor.fill.svg */ = {isa = PBXFileReference; path = ph.tractor.fill.svg; sourceTree = "<group>"; };
 		1FF1390F58FBAEEBF3131076 /* ph.desktop-tower.svg */ = {isa = PBXFileReference; path = "ph.desktop-tower.svg"; sourceTree = "<group>"; };
 		1FFA097B29D368B3D258DC22 /* ph.push-pin.svg */ = {isa = PBXFileReference; path = "ph.push-pin.svg"; sourceTree = "<group>"; };
+		200F746C5505FF0EBFE205DA /* HistoryRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryRenderingTests.swift; sourceTree = "<group>"; };
 		2015876131A8AE52D26618FC /* DeeplinksSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinksSection.swift; sourceTree = "<group>"; };
 		201B80C30CEB8D818B8ED745 /* ph.paper-plane.fill.svg */ = {isa = PBXFileReference; path = "ph.paper-plane.fill.svg"; sourceTree = "<group>"; };
 		209B9813131838B9CF86E3B0 /* ph.shield-checkered.fill.svg */ = {isa = PBXFileReference; path = "ph.shield-checkered.fill.svg"; sourceTree = "<group>"; };
@@ -4039,6 +4062,7 @@
 		3187BF7968A6C9A630C641B2 /* ph.mouse.fill.svg */ = {isa = PBXFileReference; path = ph.mouse.fill.svg; sourceTree = "<group>"; };
 		31BD1E0F7E27ABA8E0379495 /* PreferencesManager+Shortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PreferencesManager+Shortcuts.swift"; sourceTree = "<group>"; };
 		31C33FA3CC629E041AF88B62 /* ph.scales.fill.svg */ = {isa = PBXFileReference; path = ph.scales.fill.svg; sourceTree = "<group>"; };
+		31D6ABCF7625E6ECE9BA92AC /* HistorySampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistorySampleTests.swift; sourceTree = "<group>"; };
 		31EC34B3EBA9B88A8D36E912 /* ph.arrow-elbow-right-down.svg */ = {isa = PBXFileReference; path = "ph.arrow-elbow-right-down.svg"; sourceTree = "<group>"; };
 		31F8A0F81E3FB1A8DD54F4C5 /* ph.rewind.svg */ = {isa = PBXFileReference; path = ph.rewind.svg; sourceTree = "<group>"; };
 		3207E7942C1276EC463AC9A1 /* ph.fish.fill.svg */ = {isa = PBXFileReference; path = ph.fish.fill.svg; sourceTree = "<group>"; };
@@ -4136,6 +4160,7 @@
 		3A526251FAED3E480A849D55 /* ph.pinterest-logo.svg */ = {isa = PBXFileReference; path = "ph.pinterest-logo.svg"; sourceTree = "<group>"; };
 		3A64FE68520304FDBA3B5DA0 /* ph.text-subscript.fill.svg */ = {isa = PBXFileReference; path = "ph.text-subscript.fill.svg"; sourceTree = "<group>"; };
 		3AA5293FDE6685972296DF37 /* ph.hourglass-high.fill.svg */ = {isa = PBXFileReference; path = "ph.hourglass-high.fill.svg"; sourceTree = "<group>"; };
+		3AAE4E565B030A7EE3FD6202 /* HistorySample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistorySample.swift; sourceTree = "<group>"; };
 		3AB1EEB15404B8FC1DF5F5E2 /* ph.receipt.svg */ = {isa = PBXFileReference; path = ph.receipt.svg; sourceTree = "<group>"; };
 		3AB5080821C7A4C8B001E9DE /* ph.chat-circle.fill.svg */ = {isa = PBXFileReference; path = "ph.chat-circle.fill.svg"; sourceTree = "<group>"; };
 		3AC6CF07DFE2E42105F3CA07 /* ph.ice-cream.svg */ = {isa = PBXFileReference; path = "ph.ice-cream.svg"; sourceTree = "<group>"; };
@@ -4609,6 +4634,7 @@
 		5F6825BC890AE445158F957B /* ph.door-open.svg */ = {isa = PBXFileReference; path = "ph.door-open.svg"; sourceTree = "<group>"; };
 		5F7DDACEB46FCC61F2C0FD9A /* ph.pi.fill.svg */ = {isa = PBXFileReference; path = ph.pi.fill.svg; sourceTree = "<group>"; };
 		5F9106B373923426E323828A /* ph.chalkboard-teacher.svg */ = {isa = PBXFileReference; path = "ph.chalkboard-teacher.svg"; sourceTree = "<group>"; };
+		5F9C5E2680E74B1F834B9DC7 /* HistoryStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryStoreTests.swift; sourceTree = "<group>"; };
 		5FAD54EC6BA9DD4FB4FC1898 /* ph.qr-code.svg */ = {isa = PBXFileReference; path = "ph.qr-code.svg"; sourceTree = "<group>"; };
 		5FBBCCE8F0B9CF6F8307A2FC /* ph.folder-user.svg */ = {isa = PBXFileReference; path = "ph.folder-user.svg"; sourceTree = "<group>"; };
 		5FC29FA0FF4F54EED284A27F /* ph.spinner.svg */ = {isa = PBXFileReference; path = ph.spinner.svg; sourceTree = "<group>"; };
@@ -5065,6 +5091,7 @@
 		7FCE520CF759780CEB5079DA /* ph.smiley-blank.svg */ = {isa = PBXFileReference; path = "ph.smiley-blank.svg"; sourceTree = "<group>"; };
 		7FD49E86A8F92394AD4D093F /* ph.newspaper-clipping.svg */ = {isa = PBXFileReference; path = "ph.newspaper-clipping.svg"; sourceTree = "<group>"; };
 		7FE1193FDE59AD89721BDB52 /* ph.user-circle.svg */ = {isa = PBXFileReference; path = "ph.user-circle.svg"; sourceTree = "<group>"; };
+		7FE57D3362F8C7CFF86B93ED /* HistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryStore.swift; sourceTree = "<group>"; };
 		8045890FC6772D541C073BEC /* ph.subset-proper-of.fill.svg */ = {isa = PBXFileReference; path = "ph.subset-proper-of.fill.svg"; sourceTree = "<group>"; };
 		805A7215FF0305FF8FA0AB9D /* ph.hand-withdraw.fill.svg */ = {isa = PBXFileReference; path = "ph.hand-withdraw.fill.svg"; sourceTree = "<group>"; };
 		806DDFFD21372E348D229F48 /* ph.linkedin-logo.svg */ = {isa = PBXFileReference; path = "ph.linkedin-logo.svg"; sourceTree = "<group>"; };
@@ -5874,6 +5901,7 @@
 		BE31C3F1B9DECE615DE38D2F /* ph.circle.fill.svg */ = {isa = PBXFileReference; path = ph.circle.fill.svg; sourceTree = "<group>"; };
 		BE590B38079B6C95A05326CB /* ph.arrow-bend-right-down.svg */ = {isa = PBXFileReference; path = "ph.arrow-bend-right-down.svg"; sourceTree = "<group>"; };
 		BE71A272BA8FFBF6AA83F59A /* ph.sword.svg */ = {isa = PBXFileReference; path = ph.sword.svg; sourceTree = "<group>"; };
+		BE72D4A22DF6213D91028AC5 /* SparklineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparklineView.swift; sourceTree = "<group>"; };
 		BE90C49262CF8E50964836D3 /* ph.camera-rotate.fill.svg */ = {isa = PBXFileReference; path = "ph.camera-rotate.fill.svg"; sourceTree = "<group>"; };
 		BEA50F38DF8DC510A2C425D4 /* ph.arrow-bend-up-left.svg */ = {isa = PBXFileReference; path = "ph.arrow-bend-up-left.svg"; sourceTree = "<group>"; };
 		BEDE1B574958342A15AE4908 /* ph.sim-card.fill.svg */ = {isa = PBXFileReference; path = "ph.sim-card.fill.svg"; sourceTree = "<group>"; };
@@ -6004,6 +6032,7 @@
 		C8D5277B9FCFA32504A9D8B1 /* ph.infinity.svg */ = {isa = PBXFileReference; path = ph.infinity.svg; sourceTree = "<group>"; };
 		C8F6F9CFFA200A308CE66E11 /* ph.car.fill.svg */ = {isa = PBXFileReference; path = ph.car.fill.svg; sourceTree = "<group>"; };
 		C8FCD303CB1487B6F061E204 /* ph.belt.fill.svg */ = {isa = PBXFileReference; path = ph.belt.fill.svg; sourceTree = "<group>"; };
+		C90D09DB529889E99ABBABEA /* SensorHistoryRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorHistoryRegistryTests.swift; sourceTree = "<group>"; };
 		C91A0A9F3C55630E146367F0 /* ph.drop-simple.fill.svg */ = {isa = PBXFileReference; path = "ph.drop-simple.fill.svg"; sourceTree = "<group>"; };
 		C92C2B3E0B4C89FA5291013E /* ph.stairs.fill.svg */ = {isa = PBXFileReference; path = ph.stairs.fill.svg; sourceTree = "<group>"; };
 		C94176651EDEA66D72E6F2B6 /* ph.lock.svg */ = {isa = PBXFileReference; path = ph.lock.svg; sourceTree = "<group>"; };
@@ -6439,6 +6468,7 @@
 		EBBB24A372F4F593ED1B873D /* ph.arrow-fat-line-right.fill.svg */ = {isa = PBXFileReference; path = "ph.arrow-fat-line-right.fill.svg"; sourceTree = "<group>"; };
 		EBD020879B3C8B5946A7A3BE /* ph.shooting-star.fill.svg */ = {isa = PBXFileReference; path = "ph.shooting-star.fill.svg"; sourceTree = "<group>"; };
 		EBE1F83D93C83855C5BBF5D7 /* ph.arrow-bend-right-up.fill.svg */ = {isa = PBXFileReference; path = "ph.arrow-bend-right-up.fill.svg"; sourceTree = "<group>"; };
+		EBF2A031B29CA8359771D589 /* TestServiceFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestServiceFactory.swift; sourceTree = "<group>"; };
 		EC1873BE198B62B9F23B5F9E /* ph.bowl-food.svg */ = {isa = PBXFileReference; path = "ph.bowl-food.svg"; sourceTree = "<group>"; };
 		EC4482E65F805682992016BA /* ph.map-pin-plus.svg */ = {isa = PBXFileReference; path = "ph.map-pin-plus.svg"; sourceTree = "<group>"; };
 		EC51D4FADE6FA6EF8EB27A43 /* ph.test-tube.svg */ = {isa = PBXFileReference; path = "ph.test-tube.svg"; sourceTree = "<group>"; };
@@ -6568,6 +6598,7 @@
 		F607A337F23B099E62634660 /* ph.figma-logo.svg */ = {isa = PBXFileReference; path = "ph.figma-logo.svg"; sourceTree = "<group>"; };
 		F617718C55ACA8C5DC5E9DA3 /* ph.sketch-logo.fill.svg */ = {isa = PBXFileReference; path = "ph.sketch-logo.fill.svg"; sourceTree = "<group>"; };
 		F6208983DB09160823B62BFE /* ph.network-slash.svg */ = {isa = PBXFileReference; path = "ph.network-slash.svg"; sourceTree = "<group>"; };
+		F62ACB370A54D4ED820B221D /* HistoryRendering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryRendering.swift; sourceTree = "<group>"; };
 		F63A2BD4653EE833F910FADA /* ph.chat-teardrop-text.svg */ = {isa = PBXFileReference; path = "ph.chat-teardrop-text.svg"; sourceTree = "<group>"; };
 		F65728893C69B5ADF02EE0EC /* ph.police-car.fill.svg */ = {isa = PBXFileReference; path = "ph.police-car.fill.svg"; sourceTree = "<group>"; };
 		F660B7133E7135C42E9D8237 /* ph.file-code.fill.svg */ = {isa = PBXFileReference; path = "ph.file-code.fill.svg"; sourceTree = "<group>"; };
@@ -6782,6 +6813,7 @@
 				6D6AC7C83D2E3676E42DF659 /* Controls */,
 				D2258862CCE787F231C5D76E /* DesignSystem */,
 				6449651D52E31398DDF8D76B /* HAPBridge */,
+				352D1E1C1DE5814CAC22F53A /* History */,
 				31F297AB346E189FF215E374 /* HomeAssistant */,
 				F993AEE95F23CC68310DE85E /* MenuItems */,
 				244BE2D237242FEC7E6B15A5 /* Models */,
@@ -6865,6 +6897,20 @@
 				4F3F5522A583F6D38D52B390 /* HomeAssistantBridge.swift */,
 			);
 			path = HomeAssistant;
+			sourceTree = "<group>";
+		};
+		352D1E1C1DE5814CAC22F53A /* History */ = {
+			isa = PBXGroup;
+			children = (
+				1CA453EE89AE0A4F2C628EDE /* HistoryDetailView.swift */,
+				F62ACB370A54D4ED820B221D /* HistoryRendering.swift */,
+				3AAE4E565B030A7EE3FD6202 /* HistorySample.swift */,
+				0B72FC474D5713BAB0A5D326 /* HistoryStorage.swift */,
+				7FE57D3362F8C7CFF86B93ED /* HistoryStore.swift */,
+				09ADABAA9D3B404634F73F96 /* SensorHistoryRegistry.swift */,
+				BE72D4A22DF6213D91028AC5 /* SparklineView.swift */,
+			);
+			path = History;
 			sourceTree = "<group>";
 		};
 		36CD3B99DB0861416CF68E0A /* Webhook */ = {
@@ -10085,6 +10131,9 @@
 				71887325832D4E805F89008F /* GarageDoorMenuItemTests.swift */,
 				D059BD954847C83814172714 /* HACoverMenuItemTests.swift */,
 				3961BC62634C9BBF8E78E1FA /* HAPCarbonDioxideTests.swift */,
+				200F746C5505FF0EBFE205DA /* HistoryRenderingTests.swift */,
+				31D6ABCF7625E6ECE9BA92AC /* HistorySampleTests.swift */,
+				5F9C5E2680E74B1F834B9DC7 /* HistoryStoreTests.swift */,
 				180BEA38542C4E634A93B690 /* HumidifierMenuItemTests.swift */,
 				64DD4EA4CF7186C846E795AD /* IconOverrideTests.swift */,
 				1013245D5960DD38DB94DEE0 /* IconResolverTests.swift */,
@@ -10096,9 +10145,11 @@
 				8D6209D5D4AF8B8C8228A9CB /* ProStatusCacheTests.swift */,
 				6FA15C35EE0393A2B3CB900A /* SceneMenuItemTests.swift */,
 				BBD728ACD46FED845464BDCA /* SecuritySystemMenuItemTests.swift */,
+				C90D09DB529889E99ABBABEA /* SensorHistoryRegistryTests.swift */,
 				FDE1327B194C979618F4F2DB /* SensorStateMenuItemTests.swift */,
 				5886C22FD69CFE8D168F619B /* ServiceDataTests.swift */,
 				2F34BC0FC06EE9C93C6BC637 /* SwitchMenuItemTests.swift */,
+				EBF2A031B29CA8359771D589 /* TestServiceFactory.swift */,
 				A4588D4410C203F9FB823FC5 /* ThermostatMenuItemTests.swift */,
 				4C1BB4554FA59FCE166E2B86 /* ValueConversionTests.swift */,
 				16C85B3C4A8FDF2ACD4001F3 /* ValveMenuItemTests.swift */,
@@ -13555,6 +13606,11 @@
 				9117D00CD3A0C24D4B12E783 /* HAURLValidator.swift in Sources */,
 				2801F3F8FB21111BA410C0CC /* HAValveMenuItem.swift in Sources */,
 				823ABDFECC4D6E3E63AC3E02 /* HighlightingMenuItemView.swift in Sources */,
+				BA8CB496468C7A6146F2F2B5 /* HistoryDetailView.swift in Sources */,
+				B877B029F514836C7645B564 /* HistoryRendering.swift in Sources */,
+				CE088C9A6B3A8414E199882F /* HistorySample.swift in Sources */,
+				A27B2CC098B97F1A21B4EBD5 /* HistoryStorage.swift in Sources */,
+				AE045398CB246AA83BB172EB /* HistoryStore.swift in Sources */,
 				01B676F539725570858F7D87 /* HomeAssistantBridge.swift in Sources */,
 				1B1D970956A5CA2EA213611C /* HomeAssistantClient.swift in Sources */,
 				B1A748AA4A532934DE25A62C /* HomeAssistantPlatform+Actions.swift in Sources */,
@@ -13606,6 +13662,7 @@
 				0189B807373567481D495882 /* SceneMenuItem.swift in Sources */,
 				3C96631229D69FA5FF3AC750 /* SceneStateHelper.swift in Sources */,
 				680D90D25922D1D80083CFC7 /* SecuritySystemMenuItem.swift in Sources */,
+				0636DB50383AE753F38C6DF2 /* SensorHistoryRegistry.swift in Sources */,
 				274C2F2E6B4B39F9DD2B1CD3 /* SensorKind.swift in Sources */,
 				BD9135A70B8B87D700928565 /* SensorStateMenuItem.swift in Sources */,
 				F0D475122112E46686ADF3C1 /* SensorSummaryMenuItem.swift in Sources */,
@@ -13616,6 +13673,7 @@
 				EBD10F700CEFAA9D8C99229F /* ShortcutButton.swift in Sources */,
 				874E81D53AA0FC8CD8E987EA /* SlatMenuItem.swift in Sources */,
 				B2CD8112268FB9D03A608D10 /* SmartHomePlatform.swift in Sources */,
+				0AAAAFA5D0871170CA5747A3 /* SparklineView.swift in Sources */,
 				49776CBF087EF86859BA5713 /* StartupLogger.swift in Sources */,
 				CAFADC7AC3708C1CF63E3E15 /* SwitchMenuItem.swift in Sources */,
 				85A7FA1BF8285A1BF44CEA0E /* TemperatureFormatter.swift in Sources */,
@@ -13714,6 +13772,14 @@
 				CBE86B77C443636725F3609E /* HAURLValidatorTests.swift in Sources */,
 				CCF08A0E6FB126A9A8862063 /* HAValveMenuItem.swift in Sources */,
 				610C502AF5144D05B01A8278 /* HighlightingMenuItemView.swift in Sources */,
+				28A5446CBC8A41EEBA4D7EEF /* HistoryDetailView.swift in Sources */,
+				62D93B12E6007F9F0325F6D8 /* HistoryRendering.swift in Sources */,
+				1719567A8F1DFE7989B38526 /* HistoryRenderingTests.swift in Sources */,
+				9B78CFFBC5DBDF3E3B56DB16 /* HistorySample.swift in Sources */,
+				BE5CF641403A524028763065 /* HistorySampleTests.swift in Sources */,
+				9148D96320F39AE59D52ECD1 /* HistoryStorage.swift in Sources */,
+				247E9D98CA3892EFEFD47054 /* HistoryStore.swift in Sources */,
+				681407D7E46EEF096BA7B96B /* HistoryStoreTests.swift in Sources */,
 				D85E315C4BE8D60A17874DBA /* HomeAssistantBridge.swift in Sources */,
 				48AC781DF86EF65CBC780218 /* HomeAssistantBridgeTests.swift in Sources */,
 				E28EC416F60B714C4171B585 /* HomeAssistantClient.swift in Sources */,
@@ -13765,6 +13831,8 @@
 				99982E4387F3386B2896F384 /* SceneStateHelper.swift in Sources */,
 				0D1340AA633BF40EC7B797C4 /* SecuritySystemMenuItem.swift in Sources */,
 				02A44E3CB567D2F45BD9E9AD /* SecuritySystemMenuItemTests.swift in Sources */,
+				9B48C787BC0C2C46FDDAAA17 /* SensorHistoryRegistry.swift in Sources */,
+				0EEB4EAAB99AFB8A1600F787 /* SensorHistoryRegistryTests.swift in Sources */,
 				6AAF79381BEAA086E2B0C59E /* SensorKind.swift in Sources */,
 				31920E56BD0B08D97C57157B /* SensorStateMenuItem.swift in Sources */,
 				F0ED5BBECC6D5A822297D3E6 /* SensorStateMenuItemTests.swift in Sources */,
@@ -13772,10 +13840,12 @@
 				EB177BFC46F5251C608A5E6E /* ServiceDataTests.swift in Sources */,
 				9F6ADB69D964B6EDECD22CF9 /* SlatMenuItem.swift in Sources */,
 				B6EE15CB1D179D13C4AC7D23 /* SmartHomePlatform.swift in Sources */,
+				D7D3DE6DFE4616B3A5DDA2B6 /* SparklineView.swift in Sources */,
 				9907F04B32E92E6D358D63FD /* StartupLogger.swift in Sources */,
 				4959FC69F1F23C3ABA0365A1 /* SwitchMenuItem.swift in Sources */,
 				9FBEDE4F029FFD689286563C /* SwitchMenuItemTests.swift in Sources */,
 				F5FCABEBCF642BE8C3921A78 /* TemperatureFormatter.swift in Sources */,
+				F54D0518360AA3CD59E15C50 /* TestServiceFactory.swift in Sources */,
 				94D04698ADBC211F1A888348 /* ThermostatMenuItem.swift in Sources */,
 				D8316737141E18B72DE0271C /* ThermostatMenuItemTests.swift in Sources */,
 				0E3C04C26FCF48722D26C6CE /* ToggleSwitch.swift in Sources */,

--- a/macOSBridge/History/HistoryDetailView.swift
+++ b/macOSBridge/History/HistoryDetailView.swift
@@ -1,0 +1,180 @@
+//
+//  HistoryDetailView.swift
+//  macOSBridge
+//
+//  Larger history chart shown in the row's submenu: a bigger sparkline, a
+//  min/now/max line for numeric kinds, and a 24h/7d/30d range toggle.
+//
+//  Hover support: moving the cursor over the chart replaces the stats label
+//  with the value/state at that point in time; leaving reverts to range stats.
+//
+
+import AppKit
+
+final class HistoryDetailView: NSView {
+
+    enum Range: CaseIterable {
+        case day, week, month
+        var seconds: TimeInterval {
+            switch self {
+            case .day: return 24 * 60 * 60
+            case .week: return 7 * 24 * 60 * 60
+            case .month: return 30 * 24 * 60 * 60
+            }
+        }
+        var label: String {
+            switch self {
+            case .day: return String(localized: "history.range.day", defaultValue: "24h", bundle: .macOSBridge)
+            case .week: return String(localized: "history.range.week", defaultValue: "7d", bundle: .macOSBridge)
+            case .month: return String(localized: "history.range.month", defaultValue: "30d", bundle: .macOSBridge)
+            }
+        }
+    }
+
+    private let series: SensorSeries
+    private let kind: SeriesKind
+    private let unitFormatter: (Double) -> String
+    /// Optional formatter for a binary state int (1 or 0) to a display word.
+    /// When nil, "On"/"Off" is used.
+    private let stateFormatter: ((Int) -> String)?
+
+    private let chart = SparklineView(frame: .zero)
+    private let statsLabel = NSTextField(labelWithString: "")
+    private let segmented = NSSegmentedControl()
+    private var range: Range = .day
+
+    // Reusable time formatter for hover labels.
+    private let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.timeStyle = .short
+        f.dateStyle = .none
+        return f
+    }()
+
+    /// `unitFormatter` formats a numeric value (e.g. "21.4 degrees"); for binary
+    /// kinds it is unused. `stateFormatter` converts a binary state int to a word
+    /// (e.g. "Open" for 1); pass nil to use a generic "On"/"Off".
+    init(series: SensorSeries,
+         kind: SeriesKind,
+         tint: NSColor,
+         unitFormatter: @escaping (Double) -> String,
+         stateFormatter: ((Int) -> String)? = nil) {
+        self.series = series
+        self.kind = kind
+        self.unitFormatter = unitFormatter
+        self.stateFormatter = stateFormatter
+        super.init(frame: NSRect(x: 0, y: 0, width: 260, height: 96))
+        chart.tint = tint
+        buildLayout()
+        applyRange()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func buildLayout() {
+        chart.frame = NSRect(x: 12, y: 34, width: 236, height: 44)
+        addSubview(chart)
+
+        statsLabel.frame = NSRect(x: 12, y: 12, width: 236, height: 16)
+        statsLabel.font = NSFont.systemFont(ofSize: 11)
+        statsLabel.textColor = .secondaryLabelColor
+        addSubview(statsLabel)
+
+        segmented.segmentCount = Range.allCases.count
+        for (i, r) in Range.allCases.enumerated() {
+            segmented.setLabel(r.label, forSegment: i)
+            segmented.setWidth(46, forSegment: i)
+        }
+        segmented.selectedSegment = 0
+        segmented.segmentStyle = .rounded
+        segmented.controlSize = .mini
+        segmented.target = self
+        segmented.action = #selector(rangeChanged)
+        segmented.frame = NSRect(x: 110, y: 70, width: 138, height: 20)
+        addSubview(segmented)
+
+        // Wire hover callback: show detail on move, restore stats on exit.
+        chart.onHover = { [weak self] point in
+            guard let self else { return }
+            if let point {
+                self.statsLabel.stringValue = self.hoverText(for: point)
+            } else {
+                self.applyRange()
+            }
+        }
+    }
+
+    @objc private func rangeChanged() {
+        range = Range.allCases[segmented.selectedSegment]
+        applyRange()
+    }
+
+    /// Oldest sample/transition in the series (arrays are appended in time order).
+    private var earliestTimestamp: Date? {
+        switch (series.numeric.first?.t, series.binary.first?.t) {
+        case let (n?, b?): return min(n, b)
+        case let (n?, nil): return n
+        case let (nil, b?): return b
+        default: return nil
+        }
+    }
+
+    func applyRange() {
+        let now = Date()
+        let since = now.addingTimeInterval(-range.seconds)
+        // Fit the chart to the data span so a short burst of recent activity is
+        // visible instead of a sliver in a wide window. Never wider than the
+        // selected range, never narrower than 5 minutes. This always covers all
+        // in-range data (window >= data span), so nothing is hidden.
+        let span = earliestTimestamp.map { now.timeIntervalSince($0) } ?? range.seconds
+        chart.windowOverride = min(range.seconds, max(5 * 60, span * 1.2))
+        chart.update(series: series, kind: kind, now: now)
+        if kind == .numeric, let stats = HistoryRendering.stats(series.numeric.filter { $0.t >= since }) {
+            statsLabel.stringValue = String(localized: "history.detail.stats",
+                defaultValue: "min \(unitFormatter(stats.min))   now \(unitFormatter(stats.now))   max \(unitFormatter(stats.max))",
+                bundle: .macOSBridge)
+        } else if kind == .binary {
+            let changes = series.binary.filter { $0.t >= since }.count
+            statsLabel.stringValue = String(localized: "history.detail.changes",
+                defaultValue: "\(changes) change\(changes == 1 ? "" : "s") in \(range.label)",
+                bundle: .macOSBridge)
+        } else {
+            statsLabel.stringValue = String(localized: "history.detail.no_data", defaultValue: "No data yet", bundle: .macOSBridge)
+        }
+    }
+
+    // MARK: - Hover label formatting
+
+    private func hoverText(for point: SparklineView.HoverPoint) -> String {
+        let timeStr = formattedTime(point.time)
+        switch kind {
+        case .numeric:
+            if let value = point.value {
+                return "\(unitFormatter(value))  \(timeStr)"
+            }
+            return timeStr
+        case .binary:
+            let stateStr: String
+            if let state = point.state {
+                stateStr = stateFormatter?(state)
+                    ?? (state == 1 ? String(localized: "history.state.on", defaultValue: "On", bundle: .macOSBridge)
+                                   : String(localized: "history.state.off", defaultValue: "Off", bundle: .macOSBridge))
+            } else {
+                stateStr = "-"
+            }
+            return "\(stateStr)  \(timeStr)"
+        }
+    }
+
+    private func formattedTime(_ date: Date) -> String {
+        // Include a short date when the sample is older than ~20 hours.
+        let twentyHoursAgo = Date().addingTimeInterval(-20 * 60 * 60)
+        if date < twentyHoursAgo {
+            let df = DateFormatter()
+            df.dateStyle = .short
+            df.timeStyle = .short
+            return df.string(from: date)
+        }
+        return timeFormatter.string(from: date)
+    }
+}

--- a/macOSBridge/History/HistoryRendering.swift
+++ b/macOSBridge/History/HistoryRendering.swift
@@ -1,0 +1,92 @@
+//
+//  HistoryRendering.swift
+//  macOSBridge
+//
+//  Pure geometry for sparkline/detail rendering. No AppKit so it stays testable.
+//
+
+import CoreGraphics
+import Foundation
+
+enum HistoryRendering {
+
+    /// Maps in-window numeric samples to points. x runs left->right across
+    /// [since, now]; y is inverted (max value at top y=0, min at bottom y=height).
+    /// `minRange` is a floor on the value span used for scaling: when the data
+    /// varies by less than this, the data is centred in a `minRange`-tall band so
+    /// small wobbles read as a gentle line rather than a full-height sawtooth.
+    /// Equal values (with `minRange` 0) render at mid-height.
+    static func numericPoints(_ samples: [NumericSample], width: CGFloat, height: CGFloat,
+                              since: Date, now: Date, minRange: Double = 0) -> [CGPoint] {
+        let windowed = samples.filter { $0.t >= since && $0.t <= now }
+        guard !windowed.isEmpty else { return [] }
+
+        let span = max(now.timeIntervalSince(since), 1)
+        let values = windowed.map(\.v)
+        let minV = values.min() ?? 0
+        let maxV = values.max() ?? 0
+        let mid = (minV + maxV) / 2
+        let effectiveRange = max(maxV - minV, minRange)
+        let lo = mid - effectiveRange / 2
+
+        return windowed.map { sample in
+            let x = CGFloat(sample.t.timeIntervalSince(since) / span) * width
+            let normalized: CGFloat = effectiveRange == 0 ? 0.5 : CGFloat((sample.v - lo) / effectiveRange)
+            let y = height - normalized * height
+            return CGPoint(x: x, y: y)
+        }
+    }
+
+    /// One drawable segment of a binary timeline.
+    struct Segment: Equatable {
+        let x: CGFloat
+        let width: CGFloat
+        let on: Bool
+    }
+
+    /// Expands transitions into contiguous on/off segments spanning [since, now].
+    /// The window is always filled: the state at the left edge is seeded from the
+    /// last transition at/before `since`, or - when capture only began inside the
+    /// window - inferred as the inverse of the first in-window transition. This
+    /// avoids a blank bar for a sensor that has held one state across the window.
+    static func binarySegments(_ transitions: [BinaryTransition], width: CGFloat,
+                               since: Date, now: Date) -> [Segment] {
+        guard !transitions.isEmpty else { return [] }
+
+        let span = max(now.timeIntervalSince(since), 1)
+        func x(_ date: Date) -> CGFloat {
+            CGFloat(min(max(date.timeIntervalSince(since), 0), span) / span) * width
+        }
+
+        // Transitions strictly inside the window.
+        let windowed = transitions.filter { $0.t > since && $0.t <= now }
+
+        // Seed the state at the window's left edge so the bar is never blank.
+        var effective: [BinaryTransition] = []
+        if let seed = transitions.last(where: { $0.t <= since }) {
+            effective.append(BinaryTransition(t: since, s: seed.s))
+        } else if let first = windowed.first {
+            // Capture began inside the window: before the first transition the
+            // sensor must have held the opposite state.
+            effective.append(BinaryTransition(t: since, s: first.s == 1 ? 0 : 1))
+        }
+        effective.append(contentsOf: windowed)
+        guard !effective.isEmpty else { return [] }
+
+        var segments: [Segment] = []
+        for (index, transition) in effective.enumerated() {
+            let startX = x(transition.t)
+            let endDate = index + 1 < effective.count ? effective[index + 1].t : now
+            let endX = x(endDate)
+            segments.append(Segment(x: startX, width: endX - startX, on: transition.s == 1))
+        }
+        return segments
+    }
+
+    /// min / current (last) / max for the detail header. nil when empty.
+    static func stats(_ samples: [NumericSample]) -> (min: Double, now: Double, max: Double)? {
+        guard let last = samples.last else { return nil }
+        let values = samples.map(\.v)
+        return (values.min() ?? last.v, last.v, values.max() ?? last.v)
+    }
+}

--- a/macOSBridge/History/HistorySample.swift
+++ b/macOSBridge/History/HistorySample.swift
@@ -1,0 +1,56 @@
+//
+//  HistorySample.swift
+//  macOSBridge
+//
+//  Value types for sensor history series.
+//
+
+import Foundation
+
+/// Numeric kinds (temperature, humidity) store measured samples; binary kinds
+/// (contact, motion, ...) store only state transitions.
+enum SeriesKind: String, Codable {
+    case numeric
+    case binary
+}
+
+/// One temperature/humidity reading at a point in time.
+struct NumericSample: Codable, Equatable {
+    let t: Date
+    let v: Double
+}
+
+/// One binary state transition (s == 0 or 1) at a point in time.
+struct BinaryTransition: Codable, Equatable {
+    let t: Date
+    let s: Int
+}
+
+/// A per-characteristic time series. Exactly one of `numeric`/`binary` is used,
+/// determined by `kind`.
+struct SensorSeries: Codable, Equatable {
+    let characteristicId: UUID
+    let kind: SeriesKind
+    var numeric: [NumericSample]
+    var binary: [BinaryTransition]
+
+    init(characteristicId: UUID, kind: SeriesKind) {
+        self.characteristicId = characteristicId
+        self.kind = kind
+        self.numeric = []
+        self.binary = []
+    }
+}
+
+/// What the capture layer needs to know about a tracked characteristic.
+struct SensorMeta: Equatable {
+    let seriesKind: SeriesKind
+    let name: String
+}
+
+extension SensorKind {
+    /// Temperature/humidity are numeric lines; all other kinds are binary timelines.
+    var seriesKind: SeriesKind {
+        isNumeric ? .numeric : .binary
+    }
+}

--- a/macOSBridge/History/HistoryStorage.swift
+++ b/macOSBridge/History/HistoryStorage.swift
@@ -1,0 +1,66 @@
+//
+//  HistoryStorage.swift
+//  macOSBridge
+//
+//  Persistence backend for sensor history. The protocol seam lets a future
+//  iCloud-file backend drop in without touching capture or rendering.
+//
+
+import Foundation
+
+protocol HistoryStorage {
+    func load(homeId: String) -> [UUID: SensorSeries]
+    func save(_ series: [UUID: SensorSeries], homeId: String)
+}
+
+/// Stores one JSON file per home under Application Support.
+final class FileHistoryStorage: HistoryStorage {
+
+    private let baseDirectory: URL
+    private let fileManager = FileManager.default
+
+    init(baseDirectory: URL = FileHistoryStorage.defaultDirectory()) {
+        self.baseDirectory = baseDirectory
+    }
+
+    static func defaultDirectory() -> URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        return appSupport
+            .appendingPathComponent("Itsyhome", isDirectory: true)
+            .appendingPathComponent("history", isDirectory: true)
+    }
+
+    private func fileURL(homeId: String) -> URL {
+        // Home ids are UUID strings; still sanitise to a safe filename.
+        let safe = homeId.replacingOccurrences(of: "/", with: "_")
+        return baseDirectory.appendingPathComponent("\(safe).json")
+    }
+
+    func load(homeId: String) -> [UUID: SensorSeries] {
+        guard let data = try? Data(contentsOf: fileURL(homeId: homeId)),
+              let decoded = try? JSONDecoder().decode([SensorSeries].self, from: data) else {
+            return [:]
+        }
+        return Dictionary(uniqueKeysWithValues: decoded.map { ($0.characteristicId, $0) })
+    }
+
+    func save(_ series: [UUID: SensorSeries], homeId: String) {
+        try? fileManager.createDirectory(at: baseDirectory, withIntermediateDirectories: true)
+        guard let data = try? JSONEncoder().encode(Array(series.values)) else { return }
+        try? data.write(to: fileURL(homeId: homeId), options: .atomic)
+    }
+}
+
+/// In-memory backend for tests.
+final class InMemoryHistoryStorage: HistoryStorage {
+    private var stores: [String: [UUID: SensorSeries]] = [:]
+
+    func load(homeId: String) -> [UUID: SensorSeries] {
+        stores[homeId] ?? [:]
+    }
+
+    func save(_ series: [UUID: SensorSeries], homeId: String) {
+        stores[homeId] = series
+    }
+}

--- a/macOSBridge/History/HistoryStore.swift
+++ b/macOSBridge/History/HistoryStore.swift
@@ -1,0 +1,135 @@
+//
+//  HistoryStore.swift
+//  macOSBridge
+//
+//  Captures sensor history opportunistically off the characteristic chokepoint
+//  and persists it per home. Pro-gated; see ProManager.
+//
+
+import Foundation
+
+final class HistoryStore {
+
+    static let shared = HistoryStore()
+
+    static let didChangeNotification = Notification.Name("HistoryStoreDidChange")
+
+    // Tunables (see spec).
+    private let retention: TimeInterval = 30 * 24 * 60 * 60
+    private let dedupInterval: TimeInterval = 60
+    private let numericCap = 20_000
+    private let binaryCap = 5_000
+
+    private let storage: HistoryStorage
+    private let now: () -> Date
+    private let isEnabled: () -> Bool
+
+    private var homeId = "default"
+    private var registry: [UUID: SensorMeta] = [:]
+    private var series: [UUID: SensorSeries] = [:]
+
+    init(storage: HistoryStorage = FileHistoryStorage(),
+         now: @escaping () -> Date = { Date() },
+         isEnabled: @escaping () -> Bool = { ProStatusCache.shared.isPro && PreferencesManager.shared.historyEnabled }) {
+        self.storage = storage
+        self.now = now
+        self.isEnabled = isEnabled
+    }
+
+    /// Called from rebuildMenu: sets the active home + characteristic registry and
+    /// loads that home's persisted series.
+    func configure(homeId: String, registry: [UUID: SensorMeta]) {
+        // Cancel any in-flight debounced save so it cannot write the previous
+        // home's series to the new home's file after we swap state below.
+        flushWorkItem?.cancel()
+        self.homeId = homeId
+        self.registry = registry
+        self.series = storage.load(homeId: homeId)
+    }
+
+    func series(for id: UUID) -> SensorSeries? {
+        series[id]
+    }
+
+    /// Capture entry point. No-op when disabled or the id is not a tracked sensor.
+    func record(id: UUID, value: Any) {
+        guard isEnabled(), let meta = registry[id] else { return }
+        let timestamp = now()
+        switch meta.seriesKind {
+        case .numeric:
+            guard let v = ValueConversion.toDouble(value) else { return }
+            recordNumeric(id: id, v: v, at: timestamp)
+        case .binary:
+            guard let s = ValueConversion.toInt(value) else { return }
+            recordBinary(id: id, s: s, at: timestamp)
+        }
+    }
+
+    private func recordNumeric(id: UUID, v: Double, at timestamp: Date) {
+        var s = series[id] ?? SensorSeries(characteristicId: id, kind: .numeric)
+        if let last = s.numeric.last,
+           last.v == v,
+           timestamp.timeIntervalSince(last.t) < dedupInterval {
+            return
+        }
+        s.numeric.append(NumericSample(t: timestamp, v: v))
+        trimNumeric(&s, now: timestamp)
+        series[id] = s
+        markChanged()
+    }
+
+    private func recordBinary(id: UUID, s state: Int, at timestamp: Date) {
+        var s = series[id] ?? SensorSeries(characteristicId: id, kind: .binary)
+        if let last = s.binary.last, last.s == state { return }
+        s.binary.append(BinaryTransition(t: timestamp, s: state))
+        trimBinary(&s, now: timestamp)
+        series[id] = s
+        markChanged()
+    }
+
+    private func trimNumeric(_ s: inout SensorSeries, now: Date) {
+        let cutoff = now.addingTimeInterval(-retention)
+        s.numeric.removeAll { $0.t < cutoff }
+        if s.numeric.count > numericCap {
+            s.numeric.removeFirst(s.numeric.count - numericCap)
+        }
+    }
+
+    private func trimBinary(_ s: inout SensorSeries, now: Date) {
+        let cutoff = now.addingTimeInterval(-retention)
+        s.binary.removeAll { $0.t < cutoff }
+        if s.binary.count > binaryCap {
+            s.binary.removeFirst(s.binary.count - binaryCap)
+        }
+    }
+
+    func clearAll() {
+        flushWorkItem?.cancel()
+        series = [:]
+        storage.save(series, homeId: homeId)
+        NotificationCenter.default.post(name: Self.didChangeNotification, object: nil)
+    }
+
+    // MARK: - Debounced persistence
+
+    private var flushWorkItem: DispatchWorkItem?
+
+    private func markChanged() {
+        NotificationCenter.default.post(name: Self.didChangeNotification, object: nil)
+        scheduleFlush()
+    }
+
+    private func scheduleFlush() {
+        flushWorkItem?.cancel()
+        let work = DispatchWorkItem { [weak self] in self?.flush() }
+        flushWorkItem = work
+        // 2s debounce: chatty bridges produce one write, not one-per-sample.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0, execute: work)
+    }
+
+    /// Writes the current series to storage immediately. Exposed for tests and
+    /// for app-termination flushes.
+    func flush() {
+        storage.save(series, homeId: homeId)
+    }
+}

--- a/macOSBridge/History/SensorHistoryRegistry.swift
+++ b/macOSBridge/History/SensorHistoryRegistry.swift
@@ -1,0 +1,40 @@
+//
+//  SensorHistoryRegistry.swift
+//  macOSBridge
+//
+//  Builds the characteristic-id -> SensorMeta map the HistoryStore uses to know
+//  which incoming changes to capture and whether they are numeric or binary.
+//
+
+import Foundation
+
+enum SensorHistoryRegistry {
+
+    static func build(from data: MenuData) -> [UUID: SensorMeta] {
+        var registry: [UUID: SensorMeta] = [:]
+        for accessory in data.accessories {
+            for service in accessory.services {
+                // Recognised sensor services (contact, motion, temperature/humidity
+                // sensors, ...) register their state characteristic.
+                if let kind = SensorKind(serviceType: service.serviceType),
+                   let idString = kind.stateCharacteristicId(from: service),
+                   let id = UUID(uuidString: idString) {
+                    registry[id] = SensorMeta(seriesKind: kind.seriesKind, name: service.name)
+                }
+
+                // Temperature/humidity also ride along on thermostats, AC units,
+                // humidifiers, etc. Capture those readings too (as numeric), unless
+                // the id was already registered above by a dedicated sensor service.
+                if let idString = service.currentTemperatureId,
+                   let id = UUID(uuidString: idString), registry[id] == nil {
+                    registry[id] = SensorMeta(seriesKind: .numeric, name: service.name)
+                }
+                if let idString = service.humidityId,
+                   let id = UUID(uuidString: idString), registry[id] == nil {
+                    registry[id] = SensorMeta(seriesKind: .numeric, name: service.name)
+                }
+            }
+        }
+        return registry
+    }
+}

--- a/macOSBridge/History/SparklineView.swift
+++ b/macOSBridge/History/SparklineView.swift
@@ -1,0 +1,210 @@
+//
+//  SparklineView.swift
+//  macOSBridge
+//
+//  Tiny inline trend for a sensor row: a line for numeric kinds, an on/off
+//  timeline bar for binary kinds. Renders the last 24 hours by default;
+//  set windowOverride to use a different range (used by the detail chart).
+//
+//  Hover support: when onHover is set the view installs a tracking area and
+//  calls back with the nearest data point under the cursor, or nil when the
+//  cursor leaves the view.
+//
+
+import AppKit
+
+final class SparklineView: NSView {
+
+    /// How far back the inline sparkline looks (default: 24 hours).
+    static let window: TimeInterval = 24 * 60 * 60
+
+    /// Overrides the default 24h window (used by the detail chart's range toggle).
+    var windowOverride: TimeInterval?
+
+    /// Minimum value span used to scale the numeric line, so a sensor whose
+    /// reading wobbles within a small band (e.g. an AC current-temp drifting
+    /// 1-2 degrees) reads as a gentle line, not a full-height sawtooth. In the
+    /// series' native unit (degrees C for temperature, % for humidity).
+    var numericMinRange: Double = 5
+
+    private var series: SensorSeries?
+    private var kind: SeriesKind = .numeric
+    private var referenceNow: Date = Date()
+
+    /// Tint for the line / "on" segments. Defaults to the control accent.
+    var tint: NSColor = .controlAccentColor { didSet { needsDisplay = true } }
+
+    // MARK: - Hover
+
+    struct HoverPoint {
+        let time: Date
+        let value: Double?
+        let state: Int?
+    }
+
+    /// Called with the nearest data point when the cursor moves inside the view,
+    /// or with nil when the cursor exits. Set to nil to disable hover entirely.
+    var onHover: ((HoverPoint?) -> Void)?
+
+    private var hoverX: CGFloat?
+    private var trackingArea: NSTrackingArea?
+
+    // MARK: - Init
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func update(series: SensorSeries, kind: SeriesKind, now: Date = Date()) {
+        self.series = series
+        self.kind = kind
+        self.referenceNow = now
+        needsDisplay = true
+    }
+
+    // MARK: - Tracking area
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let existing = trackingArea { removeTrackingArea(existing) }
+        // `.activeAlways` is required: this is a menu-bar app, so its menus are
+        // shown while the app is not the active app, and `.activeInActiveApp`
+        // tracking would silently never fire. Mirrors HighlightingMenuItemView.
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeAlways],
+            owner: self,
+            userInfo: nil)
+        addTrackingArea(area)
+        trackingArea = area
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        // Clear any stale cursor when the menu closes (window becomes nil) or
+        // reopens, so a fresh hover starts clean. The system re-runs
+        // updateTrackingAreas on the window change to re-establish tracking.
+        if hoverX != nil {
+            hoverX = nil
+            onHover?(nil)
+            needsDisplay = true
+        }
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        guard onHover != nil, let series else { return }
+        let loc = convert(event.locationInWindow, from: nil)
+        let x = min(max(loc.x, 0), bounds.width)
+        let since = referenceNow.addingTimeInterval(-(windowOverride ?? Self.window))
+        let fraction = bounds.width > 0 ? Double(x / bounds.width) : 0
+        let cursorTime = since.addingTimeInterval(fraction * referenceNow.timeIntervalSince(since))
+
+        let point: HoverPoint
+        switch kind {
+        case .numeric:
+            let inWindow = series.numeric.filter { $0.t >= since && $0.t <= referenceNow }
+            guard let nearest = inWindow.min(by: { abs($0.t.timeIntervalSince(cursorTime)) < abs($1.t.timeIntervalSince(cursorTime)) }) else { return }
+            point = HoverPoint(time: nearest.t, value: nearest.v, state: nil)
+        case .binary:
+            // Mirror HistoryRendering.binarySegments seeding: state at cursorTime
+            // is the last transition at/before cursorTime, or the inverse of the
+            // first in-window transition if capture began inside the window.
+            let windowed = series.binary.filter { $0.t > since && $0.t <= referenceNow }
+            let state: Int?
+            if let seed = series.binary.last(where: { $0.t <= cursorTime }) {
+                state = seed.s
+            } else if let first = windowed.first {
+                state = first.s == 1 ? 0 : 1
+            } else {
+                state = nil
+            }
+            point = HoverPoint(time: cursorTime, value: nil, state: state)
+        }
+
+        hoverX = x
+        onHover?(point)
+        needsDisplay = true
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        hoverX = nil
+        onHover?(nil)
+        needsDisplay = true
+    }
+
+    // MARK: - Drawing
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let series else { return }
+        let since = referenceNow.addingTimeInterval(-(windowOverride ?? Self.window))
+        switch kind {
+        case .numeric:
+            drawLine(series.numeric, since: since)
+        case .binary:
+            drawTimeline(series.binary, since: since)
+        }
+        drawHoverCursor(series: series, since: since)
+    }
+
+    private func drawLine(_ samples: [NumericSample], since: Date) {
+        let pts = HistoryRendering.numericPoints(samples, width: bounds.width, height: bounds.height,
+                                                 since: since, now: referenceNow, minRange: numericMinRange)
+        guard pts.count > 1 else { return }
+        let path = NSBezierPath()
+        path.lineWidth = 1.5
+        path.lineJoinStyle = .round
+        path.lineCapStyle = .round
+        path.move(to: pts[0])
+        for p in pts.dropFirst() { path.line(to: p) }
+        tint.setStroke()
+        path.stroke()
+    }
+
+    private func drawTimeline(_ transitions: [BinaryTransition], since: Date) {
+        let segments = HistoryRendering.binarySegments(transitions, width: bounds.width,
+                                                       since: since, now: referenceNow)
+        // "On" (open/detected) pops in the tint; "off" (resting) is a muted but
+        // clearly visible track so a held state reads as a filled bar, not blank.
+        let off = NSColor.secondaryLabelColor
+        for seg in segments {
+            let rect = NSRect(x: seg.x, y: bounds.midY - 5, width: max(seg.width, 1), height: 10)
+            (seg.on ? tint : off).setFill()
+            NSBezierPath(roundedRect: rect, xRadius: 2, yRadius: 2).fill()
+        }
+    }
+
+    private func drawHoverCursor(series: SensorSeries, since: Date) {
+        guard let hoverX, onHover != nil else { return }
+
+        // Vertical cursor line.
+        let line = NSBezierPath()
+        line.lineWidth = 1
+        line.move(to: CGPoint(x: hoverX, y: 0))
+        line.line(to: CGPoint(x: hoverX, y: bounds.height))
+        NSColor.secondaryLabelColor.setStroke()
+        line.stroke()
+
+        // For numeric: draw a small filled dot at the nearest sample's y position.
+        if kind == .numeric {
+            let inWindow = series.numeric.filter { $0.t >= since && $0.t <= referenceNow }
+            let pts = HistoryRendering.numericPoints(inWindow, width: bounds.width,
+                                                     height: bounds.height,
+                                                     since: since, now: referenceNow, minRange: numericMinRange)
+            // Find the point whose x is closest to hoverX.
+            if let nearest = pts.min(by: { abs($0.x - hoverX) < abs($1.x - hoverX) }) {
+                let dotRadius: CGFloat = 3
+                let dotRect = NSRect(
+                    x: nearest.x - dotRadius,
+                    y: nearest.y - dotRadius,
+                    width: dotRadius * 2,
+                    height: dotRadius * 2)
+                let dot = NSBezierPath(ovalIn: dotRect)
+                tint.setFill()
+                dot.fill()
+            }
+        }
+    }
+}

--- a/macOSBridge/MacOSController+MenuUpdates.swift
+++ b/macOSBridge/MacOSController+MenuUpdates.swift
@@ -20,6 +20,10 @@ extension MacOSController {
         WebhookServer.shared.publishCharacteristicChange(characteristicId: characteristicId, value: value)
         AutomationEngine.shared.handleCharacteristicChange(id: characteristicId, value: value)
 
+        // History capture must see every change, even while the dropdown is
+        // closed, so it sits above the menu-closed guard alongside pinned/SSE.
+        HistoryStore.shared.record(id: characteristicId, value: value)
+
         // The dropdown's rows aren't visible while it's closed, and menuWillOpen
         // re-reads every characteristic via refreshCharacteristics(), so skip the
         // recursive menu/scene walk when idle. This avoids constant main-thread

--- a/macOSBridge/MacOSController.swift
+++ b/macOSBridge/MacOSController.swift
@@ -803,6 +803,11 @@ public class MacOSController: NSObject, iOS2Mac, NSMenuDelegate, PlatformPickerD
         menuBuilder.buildMenu(into: mainMenu, with: data)
         StartupLogger.log("Menu items built — \(mainMenu.items.count) items")
 
+        HistoryStore.shared.configure(
+            homeId: data.selectedHomeId ?? "default",
+            registry: SensorHistoryRegistry.build(from: data)
+        )
+
         actionEngine.bridge = activeBridge
         actionEngine.updateMenuData(data)
         actionEngine.onCharacteristicWrite = { [weak self] characteristicId, value in

--- a/macOSBridge/MenuItems/SensorStateMenuItem.swift
+++ b/macOSBridge/MenuItems/SensorStateMenuItem.swift
@@ -120,6 +120,7 @@ class SensorStateMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRe
             valueLabel.stringValue = value.flatMap(ValueConversion.toDouble)
                 .flatMap(kind.formattedValue) ?? "—"
             iconView.image = IconResolver.icon(for: serviceData)
+            refreshHistory()
             return
         }
         let raw = value.flatMap(ValueConversion.toInt)
@@ -131,6 +132,42 @@ class SensorStateMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRe
             }
         }
         iconView.image = IconResolver.sensorIcon(for: serviceData, active: raw == 1)
+        refreshHistory()
+    }
+
+    // MARK: - History
+
+    private func refreshHistory() {
+        guard let kind, let id = stateCharacteristicId,
+              let series = HistoryStore.shared.series(for: id),
+              !series.numeric.isEmpty || !series.binary.isEmpty else {
+            submenu = nil
+            return
+        }
+
+        // Detail submenu (the expandable chart).
+        let detail = HistoryDetailView(
+            series: series,
+            kind: kind.seriesKind,
+            tint: SensorStateMenuItem.tint(for: kind),
+            unitFormatter: { kind.formattedValue($0) ?? "" },
+            stateFormatter: { state in
+                if state == 1 { return kind.stateLabels?.one ?? "On" }
+                return kind.stateLabels?.zero ?? "Off"
+            })
+        let host = NSMenuItem()
+        host.view = detail
+        let menu = NSMenu()
+        menu.addItem(host)
+        submenu = menu
+    }
+
+    private static func tint(for kind: SensorKind) -> NSColor {
+        switch kind {
+        case .temperature: return NSColor.systemOrange
+        case .humidity: return NSColor.systemTeal
+        default: return NSColor.controlAccentColor
+        }
     }
 
     /// Generic Home Assistant sensor: a binary On/Off, or a numeric reading with

--- a/macOSBridge/MenuItems/SensorSummaryMenuItem.swift
+++ b/macOSBridge/MenuItems/SensorSummaryMenuItem.swift
@@ -2,7 +2,9 @@
 //  SensorSummaryMenuItem.swift
 //  macOSBridge
 //
-//  Compact summary of temperature and humidity sensors for a room
+//  Compact summary of temperature and humidity sensors for a room.
+//  When Pro + history is enabled, the row gets a detail submenu (flyout) with
+//  a larger history chart.
 //
 
 import AppKit
@@ -67,10 +69,12 @@ class SensorSummaryMenuItem: NSMenuItem, CharacteristicUpdatable, Characteristic
         tempIconView.isHidden = !hasTemp
         containerView.addSubview(tempIconView)
 
-        currentX += iconSize + DS.Spacing.xs
+        currentX += iconSize + DS.Spacing.xs  // currentX = 12 + 24 + 4 = 40
 
         // Temperature title (top)
-        let titleY = itemHeight - 10 - 12
+        let titleY = itemHeight - 10 - 12  // = 22
+        let valueY: CGFloat = 6
+
         tempTitleLabel = NSTextField(labelWithString: String(localized: "device.sensor.temperature", defaultValue: "Temperature", bundle: .macOSBridge))
         tempTitleLabel.frame = NSRect(x: currentX, y: titleY, width: 80, height: 12)
         tempTitleLabel.font = DS.Typography.labelSmall
@@ -78,8 +82,6 @@ class SensorSummaryMenuItem: NSMenuItem, CharacteristicUpdatable, Characteristic
         tempTitleLabel.isHidden = !hasTemp
         containerView.addSubview(tempTitleLabel)
 
-        // Temperature value (bottom)
-        let valueY: CGFloat = 6
         tempValueLabel = NSTextField(labelWithString: "—")
         tempValueLabel.frame = NSRect(x: currentX, y: valueY, width: 80, height: 14)
         tempValueLabel.font = DS.Typography.labelSmall
@@ -87,7 +89,7 @@ class SensorSummaryMenuItem: NSMenuItem, CharacteristicUpdatable, Characteristic
         tempValueLabel.isHidden = !hasTemp
         containerView.addSubview(tempValueLabel)
 
-        currentX += sectionWidth
+        currentX += sectionWidth  // currentX = 40 + 115 = 155
 
         // Humidity section
         humidityIconView = NSImageView(frame: NSRect(x: currentX, y: iconY, width: iconSize, height: iconSize))
@@ -97,9 +99,8 @@ class SensorSummaryMenuItem: NSMenuItem, CharacteristicUpdatable, Characteristic
         humidityIconView.isHidden = !hasHumidity
         containerView.addSubview(humidityIconView)
 
-        currentX += iconSize + DS.Spacing.xs
+        currentX += iconSize + DS.Spacing.xs  // currentX = 155 + 24 + 4 = 183
 
-        // Humidity title (top)
         humidityTitleLabel = NSTextField(labelWithString: String(localized: "device.sensor.humidity", defaultValue: "Humidity", bundle: .macOSBridge))
         humidityTitleLabel.frame = NSRect(x: currentX, y: titleY, width: 70, height: 12)
         humidityTitleLabel.font = DS.Typography.labelSmall
@@ -107,7 +108,6 @@ class SensorSummaryMenuItem: NSMenuItem, CharacteristicUpdatable, Characteristic
         humidityTitleLabel.isHidden = !hasHumidity
         containerView.addSubview(humidityTitleLabel)
 
-        // Humidity value (bottom)
         humidityValueLabel = NSTextField(labelWithString: "—")
         humidityValueLabel.frame = NSRect(x: currentX, y: valueY, width: 70, height: 14)
         humidityValueLabel.font = DS.Typography.labelSmall
@@ -130,11 +130,13 @@ class SensorSummaryMenuItem: NSMenuItem, CharacteristicUpdatable, Characteristic
                 temperatureValues[characteristicId] = temp
             }
             updateTemperatureDisplay()
+            refreshHistory()
         } else if humidityCharacteristicIds.contains(characteristicId) {
             if let humidity = ValueConversion.toDouble(value) {
                 humidityValues[characteristicId] = humidity
             }
             updateHumidityDisplay()
+            refreshHistory()
         }
     }
 
@@ -149,13 +151,13 @@ class SensorSummaryMenuItem: NSMenuItem, CharacteristicUpdatable, Characteristic
         let maxTemp = values.last ?? 0
 
         if values.count == 1 || minTemp == maxTemp {
-            // Single value
             tempValueLabel.stringValue = TemperatureFormatter.format(minTemp, decimals: 1)
         } else {
-            // Range (smallest – largest)
+            // Range (smallest to largest); hyphens, no en/em dashes.
             let minFormatted = TemperatureFormatter.format(minTemp, decimals: 1)
             let maxFormatted = TemperatureFormatter.format(maxTemp, decimals: 1)
-            tempValueLabel.stringValue = "\(minFormatted.dropLast())–\(maxFormatted)"
+            // Drop the degree symbol from the min value so "19.5°-22°" reads cleanly.
+            tempValueLabel.stringValue = "\(minFormatted.dropLast())-\(maxFormatted)"
         }
     }
 
@@ -170,11 +172,52 @@ class SensorSummaryMenuItem: NSMenuItem, CharacteristicUpdatable, Characteristic
         let maxHumidity = values.last ?? 0
 
         if values.count == 1 || minHumidity == maxHumidity {
-            // Single value
             humidityValueLabel.stringValue = String(format: "%.0f%%", minHumidity)
         } else {
-            // Range (smallest – largest)
-            humidityValueLabel.stringValue = String(format: "%.0f–%.0f%%", minHumidity, maxHumidity)
+            humidityValueLabel.stringValue = String(format: "%.0f-%.0f%%", minHumidity, maxHumidity)
         }
+    }
+
+    // MARK: - History
+
+    private func refreshHistory() {
+        guard ProStatusCache.shared.isPro, PreferencesManager.shared.historyEnabled else { return }
+        // Build the detail submenu (the flyout chart) for the first available series.
+        rebuildSubmenu()
+    }
+
+    private func rebuildSubmenu() {
+        // Prefer temperature; fall back to humidity if there is no temp data.
+        if let tempId = temperatureCharacteristicIds.first,
+           let series = HistoryStore.shared.series(for: tempId),
+           !series.numeric.isEmpty {
+            let detail = HistoryDetailView(
+                series: series,
+                kind: .numeric,
+                tint: NSColor.systemOrange,
+                unitFormatter: { TemperatureFormatter.format($0, decimals: 1) })
+            attachSubmenu(detail)
+            return
+        }
+        if let humidId = humidityCharacteristicIds.first,
+           let series = HistoryStore.shared.series(for: humidId),
+           !series.numeric.isEmpty {
+            let detail = HistoryDetailView(
+                series: series,
+                kind: .numeric,
+                tint: NSColor.systemTeal,
+                unitFormatter: { String(format: "%.0f%%", $0) })
+            attachSubmenu(detail)
+            return
+        }
+        submenu = nil
+    }
+
+    private func attachSubmenu(_ detail: HistoryDetailView) {
+        let host = NSMenuItem()
+        host.view = detail
+        let menu = NSMenu()
+        menu.addItem(host)
+        submenu = menu
     }
 }

--- a/macOSBridge/Pro/ProManager.swift
+++ b/macOSBridge/Pro/ProManager.swift
@@ -126,6 +126,7 @@ final class ProManager: ObservableObject {
             WebhookServer.shared.stop()
             Task { await VirtualBridgeService.shared.stop() }
             AutomationEngine.shared.stop()
+            HistoryStore.shared.flush()
         }
     }
 

--- a/macOSBridge/Resources/Localizable.xcstrings
+++ b/macOSBridge/Resources/Localizable.xcstrings
@@ -18766,6 +18766,138 @@
           }
         }
       }
+    },
+    "history.detail.changes" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld change%2$@ in %3$@"
+          }
+        }
+      }
+    },
+    "history.detail.no_data" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No data yet"
+          }
+        }
+      }
+    },
+    "history.detail.stats" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "min %1$@   now %2$@   max %3$@"
+          }
+        }
+      }
+    },
+    "history.range.day" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "24h"
+          }
+        }
+      }
+    },
+    "history.range.month" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30d"
+          }
+        }
+      }
+    },
+    "history.range.week" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "7d"
+          }
+        }
+      }
+    },
+    "history.state.off" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Off"
+          }
+        }
+      }
+    },
+    "history.state.on" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "On"
+          }
+        }
+      }
+    },
+    "settings.advanced.history" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Record sensor history"
+          }
+        }
+      }
+    },
+    "settings.advanced.history_clear" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear history"
+          }
+        }
+      }
+    },
+    "settings.advanced.history_clear_label" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stored history"
+          }
+        }
+      }
+    },
+    "settings.advanced.history_subtitle" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Records temperature, humidity and sensor changes as they arrive, keeping the last 30 days."
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/macOSBridge/Settings/PreferencesManager.swift
+++ b/macOSBridge/Settings/PreferencesManager.swift
@@ -32,6 +32,7 @@ final class PreferencesManager {
         static let entityCategoryFilter = "entityCategoryFilter"
         static let simpleLightControls = "simpleLightControls"
         static let sensorSummary = "sensorSummary"
+        static let historyEnabled = "historyEnabled"
 
         // Per-home settings (use with homeKey helper)
         static let orderedFavouriteIds = "orderedFavouriteIds"
@@ -70,7 +71,8 @@ final class PreferencesManager {
             Keys.temperatureUnit: "system",
             Keys.entityCategoryFilter: "hideAll",
             Keys.simpleLightControls: false,
-            Keys.sensorSummary: true
+            Keys.sensorSummary: true,
+            Keys.historyEnabled: false
         ])
 
         // Sync launch at login state with system on init
@@ -208,6 +210,20 @@ final class PreferencesManager {
         get { defaults.integer(forKey: Keys.doorbellAutoCloseDelay) }
         set {
             defaults.set(newValue, forKey: Keys.doorbellAutoCloseDelay)
+            postNotification()
+        }
+    }
+
+    // MARK: - Sensor history (global)
+
+    /// When on, sensor readings are stored for 30 days and shown as an
+    /// expandable chart in each sensor's submenu. Opt-in (default off) and
+    /// Pro-gated in the UI; the store itself also checks Pro status before
+    /// recording.
+    var historyEnabled: Bool {
+        get { defaults.bool(forKey: Keys.historyEnabled) }
+        set {
+            defaults.set(newValue, forKey: Keys.historyEnabled)
             postNotification()
         }
     }

--- a/macOSBridge/Settings/Sections/AdvancedSection.swift
+++ b/macOSBridge/Settings/Sections/AdvancedSection.swift
@@ -12,6 +12,7 @@ class AdvancedSection: SettingsCard {
     private let temperaturePopUp = NSPopUpButton()
     private let simpleLightSwitch = NSSwitch()
     private let sensorSummarySwitch = NSSwitch()
+    private let historySwitch = NSSwitch()
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -67,6 +68,35 @@ class AdvancedSection: SettingsCard {
         addContentToBox(sensorBox, content: sensorRow)
         stackView.addArrangedSubview(sensorBox)
         sensorBox.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+
+        // Sensor history toggle box
+        let historyBox = createCardBox()
+        historySwitch.controlSize = .mini
+        historySwitch.target = self
+        historySwitch.action = #selector(historySwitchChanged(_:))
+        let historyRow = createSettingRow(
+            label: String(localized: "settings.advanced.history", defaultValue: "Record sensor history", bundle: .macOSBridge),
+            subtitle: String(localized: "settings.advanced.history_subtitle", defaultValue: "Records temperature, humidity and sensor changes as they arrive, keeping the last 30 days.", bundle: .macOSBridge),
+            control: historySwitch
+        )
+        addContentToBox(historyBox, content: historyRow)
+        stackView.addArrangedSubview(historyBox)
+        historyBox.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+
+        // Clear history box (separate box - addContentToBox pins to all 4 edges)
+        let clearBox = createCardBox()
+        let clearButton = NSButton(
+            title: String(localized: "settings.advanced.history_clear", defaultValue: "Clear history", bundle: .macOSBridge),
+            target: self, action: #selector(clearHistory))
+        clearButton.bezelStyle = .rounded
+        clearButton.controlSize = .small
+        let clearRow = createSettingRow(
+            label: String(localized: "settings.advanced.history_clear_label", defaultValue: "Stored history", bundle: .macOSBridge),
+            control: clearButton
+        )
+        addContentToBox(clearBox, content: clearRow)
+        stackView.addArrangedSubview(clearBox)
+        clearBox.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
     }
 
     private func createCardBox() -> NSView {
@@ -139,6 +169,7 @@ class AdvancedSection: SettingsCard {
         }
         simpleLightSwitch.state = PreferencesManager.shared.simpleLightControls ? .on : .off
         sensorSummarySwitch.state = PreferencesManager.shared.sensorSummary ? .on : .off
+        historySwitch.state = PreferencesManager.shared.historyEnabled ? .on : .off
     }
 
     @objc private func temperatureUnitChanged(_ sender: NSPopUpButton) {
@@ -152,5 +183,13 @@ class AdvancedSection: SettingsCard {
 
     @objc private func sensorSummarySwitchChanged(_ sender: NSSwitch) {
         PreferencesManager.shared.sensorSummary = sender.state == .on
+    }
+
+    @objc private func historySwitchChanged(_ sender: NSSwitch) {
+        PreferencesManager.shared.historyEnabled = sender.state == .on
+    }
+
+    @objc private func clearHistory() {
+        HistoryStore.shared.clearAll()
     }
 }

--- a/macOSBridgeTests/HistoryRenderingTests.swift
+++ b/macOSBridgeTests/HistoryRenderingTests.swift
@@ -1,0 +1,133 @@
+//
+//  HistoryRenderingTests.swift
+//  macOSBridgeTests
+//
+
+import XCTest
+import CoreGraphics
+@testable import macOSBridge
+
+final class HistoryRenderingTests: XCTestCase {
+
+    private let since = Date(timeIntervalSince1970: 0)
+    private let now = Date(timeIntervalSince1970: 100)
+
+    func testNumericPointsMapTimeToXAndValueToInvertedY() {
+        let samples = [
+            NumericSample(t: Date(timeIntervalSince1970: 0), v: 10),
+            NumericSample(t: Date(timeIntervalSince1970: 50), v: 20),
+            NumericSample(t: Date(timeIntervalSince1970: 100), v: 30),
+        ]
+        let points = HistoryRendering.numericPoints(samples, width: 100, height: 10, since: since, now: now)
+
+        XCTAssertEqual(points.count, 3)
+        // x maps left-to-right across the window.
+        XCTAssertEqual(points[0].x, 0, accuracy: 0.001)
+        XCTAssertEqual(points[1].x, 50, accuracy: 0.001)
+        XCTAssertEqual(points[2].x, 100, accuracy: 0.001)
+        // y is inverted: min value -> bottom (height), max value -> top (0).
+        XCTAssertEqual(points[0].y, 10, accuracy: 0.001)
+        XCTAssertEqual(points[2].y, 0, accuracy: 0.001)
+    }
+
+    func testNumericPointsFlatLineWhenAllEqual() {
+        let samples = [
+            NumericSample(t: Date(timeIntervalSince1970: 0), v: 21),
+            NumericSample(t: Date(timeIntervalSince1970: 100), v: 21),
+        ]
+        let points = HistoryRendering.numericPoints(samples, width: 100, height: 10, since: since, now: now)
+        // Equal values render mid-height, not NaN.
+        XCTAssertEqual(points[0].y, 5, accuracy: 0.001)
+        XCTAssertEqual(points[1].y, 5, accuracy: 0.001)
+    }
+
+    func testNumericPointsEmptyForNoSamples() {
+        XCTAssertTrue(HistoryRendering.numericPoints([], width: 100, height: 10, since: since, now: now).isEmpty)
+    }
+
+    func testNumericPointsClampsSmallVariationToMinRange() {
+        // Values vary by 1 but minRange is 10: the data should occupy ~10% of the
+        // height, centred, rather than filling it (the anti-sawtooth behaviour).
+        let samples = [
+            NumericSample(t: Date(timeIntervalSince1970: 0), v: 20),
+            NumericSample(t: Date(timeIntervalSince1970: 100), v: 21),
+        ]
+        let pts = HistoryRendering.numericPoints(samples, width: 100, height: 100,
+                                                 since: since, now: now, minRange: 10)
+        // mid = 20.5, effectiveRange = 10, lo = 15.5 -> 20 maps to 0.45, 21 to 0.55.
+        XCTAssertEqual(pts[0].y, 55, accuracy: 0.01)
+        XCTAssertEqual(pts[1].y, 45, accuracy: 0.01)
+    }
+
+    func testBinarySegmentsSpanWindowByState() {
+        // Open at t=0, closed at t=50; window is [0,100].
+        let transitions = [
+            BinaryTransition(t: Date(timeIntervalSince1970: 0), s: 1),
+            BinaryTransition(t: Date(timeIntervalSince1970: 50), s: 0),
+        ]
+        let segments = HistoryRendering.binarySegments(transitions, width: 100, since: since, now: now)
+
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(segments[0].x, 0, accuracy: 0.001)
+        XCTAssertEqual(segments[0].width, 50, accuracy: 0.001)
+        XCTAssertTrue(segments[0].on)
+        XCTAssertEqual(segments[1].x, 50, accuracy: 0.001)
+        XCTAssertEqual(segments[1].width, 50, accuracy: 0.001)
+        XCTAssertFalse(segments[1].on)
+    }
+
+    func testBinarySegmentsSeedsStateWhenLastTransitionPredatesWindow() {
+        // Door opened before the window and held open: no transition inside
+        // [since, now], so the whole window must read as a single "on" bar.
+        let transitions = [BinaryTransition(t: Date(timeIntervalSince1970: -10), s: 1)]
+        let segments = HistoryRendering.binarySegments(transitions, width: 100, since: since, now: now)
+
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0].x, 0, accuracy: 0.001)
+        XCTAssertEqual(segments[0].width, 100, accuracy: 0.001)
+        XCTAssertTrue(segments[0].on)
+    }
+
+    func testBinarySegmentsInfersPriorStateWhenCaptureBeganInsideWindow() {
+        // First-ever sample is an "open" inside the window: before it, the sensor
+        // must have been closed, so the lead-in segment fills as "off".
+        let transitions = [BinaryTransition(t: Date(timeIntervalSince1970: 80), s: 1)]
+        let segments = HistoryRendering.binarySegments(transitions, width: 100, since: since, now: now)
+
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertFalse(segments[0].on)                       // inferred closed lead-in
+        XCTAssertEqual(segments[0].width, 80, accuracy: 0.001)
+        XCTAssertTrue(segments[1].on)                        // the open period to now
+        XCTAssertEqual(segments[1].width, 20, accuracy: 0.001)
+    }
+
+    func testStatsReturnsMinNowMax() {
+        let samples = [
+            NumericSample(t: Date(timeIntervalSince1970: 0), v: 18),
+            NumericSample(t: Date(timeIntervalSince1970: 50), v: 23),
+            NumericSample(t: Date(timeIntervalSince1970: 100), v: 21),
+        ]
+        let stats = HistoryRendering.stats(samples)
+        XCTAssertEqual(stats?.min, 18)
+        XCTAssertEqual(stats?.max, 23)
+        XCTAssertEqual(stats?.now, 21)   // last sample
+        XCTAssertNil(HistoryRendering.stats([]))
+    }
+
+    func testSparklineViewAcceptsNumericAndBinarySeriesWithoutCrash() {
+        let frame = CGRect(x: 0, y: 0, width: 48, height: 16)
+
+        var numeric = SensorSeries(characteristicId: UUID(), kind: .numeric)
+        numeric.numeric = [NumericSample(t: Date(timeIntervalSince1970: 0), v: 20)]
+        let v1 = SparklineView(frame: frame)
+        v1.update(series: numeric, kind: .numeric, now: Date(timeIntervalSince1970: 10))
+
+        var binary = SensorSeries(characteristicId: UUID(), kind: .binary)
+        binary.binary = [BinaryTransition(t: Date(timeIntervalSince1970: 0), s: 1)]
+        let v2 = SparklineView(frame: frame)
+        v2.update(series: binary, kind: .binary, now: Date(timeIntervalSince1970: 10))
+
+        XCTAssertEqual(v1.frame.width, 48)
+        XCTAssertEqual(v2.frame.width, 48)
+    }
+}

--- a/macOSBridgeTests/HistorySampleTests.swift
+++ b/macOSBridgeTests/HistorySampleTests.swift
@@ -1,0 +1,27 @@
+//
+//  HistorySampleTests.swift
+//  macOSBridgeTests
+//
+
+import XCTest
+@testable import macOSBridge
+
+final class HistorySampleTests: XCTestCase {
+
+    func testSensorKindMapsToSeriesKind() {
+        XCTAssertEqual(SensorKind.temperature.seriesKind, .numeric)
+        XCTAssertEqual(SensorKind.humidity.seriesKind, .numeric)
+        for binary in [SensorKind.contact, .motion, .occupancy, .leak, .smoke, .carbonMonoxide, .carbonDioxide] {
+            XCTAssertEqual(binary.seriesKind, .binary, "\(binary) should be binary")
+        }
+    }
+
+    func testSensorSeriesJSONRoundTrip() throws {
+        let t = Date(timeIntervalSince1970: 1_700_000_000)
+        var series = SensorSeries(characteristicId: UUID(), kind: .numeric)
+        series.numeric = [NumericSample(t: t, v: 21.4)]
+        let data = try JSONEncoder().encode(series)
+        let decoded = try JSONDecoder().decode(SensorSeries.self, from: data)
+        XCTAssertEqual(decoded, series)
+    }
+}

--- a/macOSBridgeTests/HistoryStoreTests.swift
+++ b/macOSBridgeTests/HistoryStoreTests.swift
@@ -1,0 +1,139 @@
+//
+//  HistoryStoreTests.swift
+//  macOSBridgeTests
+//
+
+import XCTest
+@testable import macOSBridge
+
+final class HistoryStoreTests: XCTestCase {
+
+    func testFileStorageRoundTripsPerHome() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("history-test-\(UUID().uuidString)")
+        let storage = FileHistoryStorage(baseDirectory: tmp)
+
+        let id = UUID()
+        var series = SensorSeries(characteristicId: id, kind: .numeric)
+        series.numeric = [NumericSample(t: Date(timeIntervalSince1970: 1), v: 9.0)]
+
+        storage.save([id: series], homeId: "home-A")
+        // A different home must not see home-A's data.
+        XCTAssertTrue(storage.load(homeId: "home-B").isEmpty)
+        XCTAssertEqual(storage.load(homeId: "home-A")[id], series)
+
+        try? FileManager.default.removeItem(at: tmp)
+    }
+
+    // MARK: - Task 3: record + dedup
+
+    // A store wired to in-memory storage, a controllable clock, and always-enabled.
+    private func makeStore(now: @escaping () -> Date) -> HistoryStore {
+        let store = HistoryStore(storage: InMemoryHistoryStorage(), now: now, isEnabled: { true })
+        return store
+    }
+
+    func testNumericDedupSkipsUnchangedWithinInterval() {
+        var clock = Date(timeIntervalSince1970: 1000)
+        let store = makeStore(now: { clock })
+        let id = UUID()
+        store.configure(homeId: "h", registry: [id: SensorMeta(seriesKind: .numeric, name: "Temp")])
+
+        store.record(id: id, value: 21.0)
+        clock = clock.addingTimeInterval(10)   // < 60s, same value
+        store.record(id: id, value: 21.0)
+
+        XCTAssertEqual(store.series(for: id)?.numeric.count, 1)
+    }
+
+    func testNumericRecordsOnChangeOrAfterInterval() {
+        var clock = Date(timeIntervalSince1970: 1000)
+        let store = makeStore(now: { clock })
+        let id = UUID()
+        store.configure(homeId: "h", registry: [id: SensorMeta(seriesKind: .numeric, name: "Temp")])
+
+        store.record(id: id, value: 21.0)
+        clock = clock.addingTimeInterval(10)
+        store.record(id: id, value: 22.0)        // changed -> records
+        clock = clock.addingTimeInterval(120)
+        store.record(id: id, value: 22.0)        // unchanged but > 60s -> records
+
+        XCTAssertEqual(store.series(for: id)?.numeric.count, 3)
+    }
+
+    func testBinaryRecordsOnlyTransitions() {
+        var clock = Date(timeIntervalSince1970: 1000)
+        let store = makeStore(now: { clock })
+        let id = UUID()
+        store.configure(homeId: "h", registry: [id: SensorMeta(seriesKind: .binary, name: "Door")])
+
+        store.record(id: id, value: 1)   // open
+        clock = clock.addingTimeInterval(5)
+        store.record(id: id, value: 1)   // still open -> skip
+        clock = clock.addingTimeInterval(5)
+        store.record(id: id, value: 0)   // closed -> records
+
+        XCTAssertEqual(store.series(for: id)?.binary.map(\.s), [1, 0])
+    }
+
+    func testUnregisteredIdIsIgnored() {
+        let store = makeStore(now: { Date() })
+        store.configure(homeId: "h", registry: [:])
+        store.record(id: UUID(), value: 21.0)
+        // No registry entry -> nothing recorded, no crash.
+        XCTAssertNil(store.series(for: UUID()))
+    }
+
+    func testDisabledStoreDoesNotRecord() {
+        let store = HistoryStore(storage: InMemoryHistoryStorage(), now: { Date() }, isEnabled: { false })
+        let id = UUID()
+        store.configure(homeId: "h", registry: [id: SensorMeta(seriesKind: .numeric, name: "Temp")])
+        store.record(id: id, value: 21.0)
+        XCTAssertNil(store.series(for: id))
+    }
+
+    // MARK: - Task 4: retention, caps, clearAll, debounced persistence
+
+    func testRetentionDropsSamplesOlderThan30Days() {
+        var clock = Date(timeIntervalSince1970: 2_000_000_000)
+        let store = makeStore(now: { clock })
+        let id = UUID()
+        store.configure(homeId: "h", registry: [id: SensorMeta(seriesKind: .numeric, name: "Temp")])
+
+        store.record(id: id, value: 10.0)                       // t0
+        clock = clock.addingTimeInterval(31 * 24 * 60 * 60)     // +31 days
+        store.record(id: id, value: 11.0)                       // triggers trim of t0
+
+        let samples = store.series(for: id)?.numeric ?? []
+        XCTAssertEqual(samples.map(\.v), [11.0])
+    }
+
+    func testClearAllEmptiesAndPersists() {
+        let storage = InMemoryHistoryStorage()
+        let store = HistoryStore(storage: storage, now: { Date(timeIntervalSince1970: 1) }, isEnabled: { true })
+        let id = UUID()
+        store.configure(homeId: "h", registry: [id: SensorMeta(seriesKind: .numeric, name: "Temp")])
+        store.record(id: id, value: 10.0)
+        XCTAssertNotNil(store.series(for: id))
+
+        store.clearAll()
+
+        XCTAssertNil(store.series(for: id))
+        XCTAssertTrue(storage.load(homeId: "h").isEmpty)
+    }
+
+    func testRecordedDataReloadsFromStorageOnReconfigure() {
+        let storage = InMemoryHistoryStorage()
+        let id = UUID()
+        let meta = SensorMeta(seriesKind: .numeric, name: "Temp")
+        let store1 = HistoryStore(storage: storage, now: { Date(timeIntervalSince1970: 5) }, isEnabled: { true })
+        store1.configure(homeId: "h", registry: [id: meta])
+        store1.record(id: id, value: 21.0)
+        store1.flush()
+
+        // A fresh store with the same storage reloads the persisted series.
+        let store2 = HistoryStore(storage: storage, now: { Date(timeIntervalSince1970: 6) }, isEnabled: { true })
+        store2.configure(homeId: "h", registry: [id: meta])
+        XCTAssertEqual(store2.series(for: id)?.numeric.map(\.v), [21.0])
+    }
+}

--- a/macOSBridgeTests/SensorHistoryRegistryTests.swift
+++ b/macOSBridgeTests/SensorHistoryRegistryTests.swift
@@ -1,0 +1,81 @@
+//
+//  SensorHistoryRegistryTests.swift
+//  macOSBridgeTests
+//
+
+import XCTest
+@testable import macOSBridge
+
+final class SensorHistoryRegistryTests: XCTestCase {
+
+    func testBuildMapsTemperatureToNumericByCharacteristicId() {
+        let tempId = UUID()
+        let service = TestServiceFactory.sensor(
+            serviceType: ServiceTypes.temperatureSensor,
+            name: "Living Room",
+            currentTemperatureId: tempId.uuidString
+        )
+        let data = TestServiceFactory.menuData(services: [service])
+
+        let registry = SensorHistoryRegistry.build(from: data)
+
+        XCTAssertEqual(registry[tempId], SensorMeta(seriesKind: .numeric, name: "Living Room"))
+    }
+
+    func testBuildMapsContactToBinary() {
+        let contactId = UUID()
+        let service = TestServiceFactory.sensor(
+            serviceType: ServiceTypes.contactSensor,
+            name: "Front Door",
+            contactSensorStateId: contactId.uuidString
+        )
+        let data = TestServiceFactory.menuData(services: [service])
+
+        let registry = SensorHistoryRegistry.build(from: data)
+
+        XCTAssertEqual(registry[contactId], SensorMeta(seriesKind: .binary, name: "Front Door"))
+    }
+
+    func testNonSensorServiceIsIgnored() {
+        let service = TestServiceFactory.sensor(serviceType: "unknown.service.type", name: "Lamp")
+        let data = TestServiceFactory.menuData(services: [service])
+        XCTAssertTrue(SensorHistoryRegistry.build(from: data).isEmpty)
+    }
+
+    // MARK: - Non-sensor service with temperature/humidity (thermostat, AC, etc.)
+
+    func testThermostatServiceWithTemperatureIdIsRegisteredAsNumeric() {
+        // A thermostat is not a SensorKind, but its currentTemperatureId should
+        // still be captured as numeric.
+        let tempId = UUID()
+        let service = TestServiceFactory.sensor(
+            serviceType: ServiceTypes.thermostat,
+            name: "Living Room Thermostat",
+            currentTemperatureId: tempId.uuidString
+        )
+        let data = TestServiceFactory.menuData(services: [service])
+
+        let registry = SensorHistoryRegistry.build(from: data)
+
+        XCTAssertEqual(registry[tempId], SensorMeta(seriesKind: .numeric, name: "Living Room Thermostat"))
+    }
+
+    func testDedicatedTemperatureSensorIsRegisteredExactlyOnce() {
+        // A dedicated temperature sensor service has both a SensorKind path and a
+        // currentTemperatureId. The registry must not double-count it: the final
+        // result should contain the ID exactly once, as numeric.
+        let tempId = UUID()
+        let service = TestServiceFactory.sensor(
+            serviceType: ServiceTypes.temperatureSensor,
+            name: "Bedroom Sensor",
+            currentTemperatureId: tempId.uuidString
+        )
+        let data = TestServiceFactory.menuData(services: [service])
+
+        let registry = SensorHistoryRegistry.build(from: data)
+
+        // Exactly one entry for this characteristic.
+        XCTAssertEqual(registry.count, 1)
+        XCTAssertEqual(registry[tempId], SensorMeta(seriesKind: .numeric, name: "Bedroom Sensor"))
+    }
+}

--- a/macOSBridgeTests/TestServiceFactory.swift
+++ b/macOSBridgeTests/TestServiceFactory.swift
@@ -1,0 +1,70 @@
+//
+//  TestServiceFactory.swift
+//  macOSBridgeTests
+//
+//  Convenience factory that builds ServiceData / MenuData values for tests.
+//  Uses the real ServiceData/AccessoryData/MenuData initializers from
+//  BridgeProtocols.swift - all characteristic id parameters accept UUID strings
+//  (matching how tests hold IDs) and are converted internally to UUID for the
+//  real init.
+//
+
+import Foundation
+@testable import macOSBridge
+
+enum TestServiceFactory {
+
+    /// Build a ServiceData for a sensor service. All characteristic id parameters
+    /// are optional UUID strings; pass only the ones relevant to the service type
+    /// under test. Unrecognised service types produce a service with no
+    /// characteristic ids, which exercises the "non-sensor is ignored" path.
+    static func sensor(
+        serviceType: String,
+        name: String,
+        currentTemperatureId: String? = nil,
+        humidityId: String? = nil,
+        motionDetectedId: String? = nil,
+        contactSensorStateId: String? = nil,
+        occupancyDetectedId: String? = nil,
+        leakDetectedId: String? = nil,
+        smokeDetectedId: String? = nil,
+        carbonMonoxideDetectedId: String? = nil,
+        carbonDioxideDetectedId: String? = nil
+    ) -> ServiceData {
+        ServiceData(
+            uniqueIdentifier: UUID(),
+            name: name,
+            serviceType: serviceType,
+            accessoryName: name,
+            roomIdentifier: nil,
+            currentTemperatureId: currentTemperatureId.flatMap(UUID.init(uuidString:)),
+            humidityId: humidityId.flatMap(UUID.init(uuidString:)),
+            motionDetectedId: motionDetectedId.flatMap(UUID.init(uuidString:)),
+            contactSensorStateId: contactSensorStateId.flatMap(UUID.init(uuidString:)),
+            occupancyDetectedId: occupancyDetectedId.flatMap(UUID.init(uuidString:)),
+            leakDetectedId: leakDetectedId.flatMap(UUID.init(uuidString:)),
+            smokeDetectedId: smokeDetectedId.flatMap(UUID.init(uuidString:)),
+            carbonMonoxideDetectedId: carbonMonoxideDetectedId.flatMap(UUID.init(uuidString:)),
+            carbonDioxideDetectedId: carbonDioxideDetectedId.flatMap(UUID.init(uuidString:))
+        )
+    }
+
+    /// Wrap one or more ServiceData values in a single AccessoryData inside a
+    /// MenuData. Sufficient for all SensorHistoryRegistry tests.
+    static func menuData(services: [ServiceData]) -> MenuData {
+        let accessory = AccessoryData(
+            uniqueIdentifier: UUID(),
+            name: "Test Accessory",
+            roomIdentifier: nil as UUID?,
+            services: services,
+            isReachable: true
+        )
+        return MenuData(
+            homes: [],
+            rooms: [],
+            accessories: [accessory],
+            scenes: [],
+            selectedHomeId: nil as UUID?
+        )
+    }
+}


### PR DESCRIPTION
Opt-in 30-day history per sensor, shown as a chart in each sensor's submenu.

- Temperature & humidity render as a line chart; contact/motion/occupancy/ leak/smoke/CO/CO2 render as an on/off timeline. Thermostat & AC current- temperature is captured too and surfaced on the Temperature summary row.
- Hover the chart for the value/state at a point in time; 24h/7d/30d range toggle in the flyout.
- Captures off the existing menu-update path (no extra polling); numeric series de-dup at 60s, binary sensors store transitions only.
- Local on-disk storage per home, 30-day retention with caps. iCloud-ready layout; no iCloud sync in v1.
- Gated behind Pro and an opt-in "Record sensor history" switch in Advanced, with a "Clear history" button.