### PR TITLE
fix: sensor history chart missing on some rows

### DIFF
--- a/macOSBridge/MacOSController.swift
+++ b/macOSBridge/MacOSController.swift
@@ -799,14 +799,19 @@ public class MacOSController: NSObject, iOS2Mac, NSMenuDelegate, PlatformPickerD
         HotkeyManager.shared.registerShortcuts()
 
         menuBuilder.bridge = activeBridge
-        StartupLogger.log("Building menu items...")
-        menuBuilder.buildMenu(into: mainMenu, with: data)
-        StartupLogger.log("Menu items built — \(mainMenu.items.count) items")
 
+        // Load persisted history BEFORE building the menu so each sensor row can
+        // build its history submenu from loaded data. Otherwise rarely-changing
+        // rows (contact/motion) stay empty until they next change, while temps
+        // repopulate via their stream. See SensorStateMenuItem.refreshHistory.
         HistoryStore.shared.configure(
             homeId: data.selectedHomeId ?? "default",
             registry: SensorHistoryRegistry.build(from: data)
         )
+
+        StartupLogger.log("Building menu items...")
+        menuBuilder.buildMenu(into: mainMenu, with: data)
+        StartupLogger.log("Menu items built — \(mainMenu.items.count) items")
 
         actionEngine.bridge = activeBridge
         actionEngine.updateMenuData(data)

--- a/macOSBridge/MenuItems/SensorStateMenuItem.swift
+++ b/macOSBridge/MenuItems/SensorStateMenuItem.swift
@@ -138,6 +138,13 @@ class SensorStateMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRe
     // MARK: - History
 
     private func refreshHistory() {
+        // Match the summary row: history is a Pro feature gated on the toggle, so
+        // "Record sensor history" off means no chart on any row (not just the
+        // temperature/humidity summary).
+        guard ProStatusCache.shared.isPro, PreferencesManager.shared.historyEnabled else {
+            submenu = nil
+            return
+        }
         guard let kind, let id = stateCharacteristicId,
               let series = HistoryStore.shared.series(for: id),
               !series.numeric.isEmpty || !series.binary.isEmpty else {


### PR DESCRIPTION
Two display fixes for the sensor history charts:

- Configure the history store before building the menu, not after. buildMenu constructs each sensor row's history submenu, so configuring afterwards left rarely-changing rows (contact/motion) with an empty submenu until they next changed. Temperature rows masked this by repopulating from their stream; binary sensors showed no chart at all on a cold start.

- Gate the single-sensor rows' chart on Pro + the "Record sensor history" toggle, matching the temperature/humidity summary row. Previously a single row could show a chart while the summary (and the toggle) reported history as off.