### PR TITLE
fix: stop camera streams from ducking system audio

### DIFF
--- a/Itsyhome/iOS/HLSStreamPlayer.swift
+++ b/Itsyhome/iOS/HLSStreamPlayer.swift
@@ -38,6 +38,10 @@ final class HLSStreamPlayer: NSObject {
     func play(url: URL) {
         logger.info("Starting HLS playback: \(url.absoluteString)")
 
+        let audioSession = AVAudioSession.sharedInstance()
+        try? audioSession.setCategory(.playback, options: [.mixWithOthers])
+        try? audioSession.setActive(true)
+
         let asset = AVURLAsset(url: url)
         let playerItem = AVPlayerItem(asset: asset)
 
@@ -111,6 +115,8 @@ final class HLSStreamPlayer: NSObject {
         playerLayer = nil
         playerView = nil
         player = nil
+
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 
     func setMuted(_ muted: Bool) {

--- a/Itsyhome/iOS/HLSStreamPlayer.swift
+++ b/Itsyhome/iOS/HLSStreamPlayer.swift
@@ -27,20 +27,23 @@ final class HLSStreamPlayer: NSObject {
     private var playerView: UIView?
     private var statusObserver: NSKeyValueObservation?
     private var errorObserver: NSKeyValueObservation?
+    private var didActivateAudioSession = false
 
     var onError: ((Error) -> Void)?
     var onReady: (() -> Void)?
 
     var view: UIView? { playerView }
 
+    deinit {
+        stop()
+    }
+
     // MARK: - Playback
 
     func play(url: URL) {
         logger.info("Starting HLS playback: \(url.absoluteString)")
 
-        let audioSession = AVAudioSession.sharedInstance()
-        try? audioSession.setCategory(.playback, options: [.mixWithOthers])
-        try? audioSession.setActive(true)
+        activateAudioSessionIfNeeded()
 
         let asset = AVURLAsset(url: url)
         let playerItem = AVPlayerItem(asset: asset)
@@ -116,10 +119,34 @@ final class HLSStreamPlayer: NSObject {
         playerView = nil
         player = nil
 
-        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        deactivateAudioSessionIfNeeded()
     }
 
     func setMuted(_ muted: Bool) {
         player?.isMuted = muted
+    }
+
+    private func activateAudioSessionIfNeeded() {
+        guard !didActivateAudioSession else { return }
+
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            try audioSession.setCategory(.playback, options: [.mixWithOthers])
+            try audioSession.setActive(true)
+            didActivateAudioSession = true
+        } catch {
+            logger.error("Failed to activate HLS audio session: \(error.localizedDescription)")
+        }
+    }
+
+    private func deactivateAudioSessionIfNeeded() {
+        guard didActivateAudioSession else { return }
+
+        do {
+            try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+            didActivateAudioSession = false
+        } catch {
+            logger.error("Failed to deactivate HLS audio session: \(error.localizedDescription)")
+        }
     }
 }

--- a/Itsyhome/iOS/WebRTCStreamClient.swift
+++ b/Itsyhome/iOS/WebRTCStreamClient.swift
@@ -26,6 +26,7 @@ final class WebRTCStreamClient: NSObject {
 
     private var entityId: String?
     private var signaling: HACameraSignaling?
+    private var didActivateAudioSession = false
 
     // MARK: - Initialization
 
@@ -46,7 +47,7 @@ final class WebRTCStreamClient: NSObject {
     func connect(entityId: String, signaling: HACameraSignaling, dataChannelLabel: String? = nil) async throws {
         self.entityId = entityId
         self.signaling = signaling
-        configureAudioSession(active: true)
+        setAudioSessionActive(true)
 
         // Configure ICE servers (STUN only — HA WebRTC typically uses direct connectivity)
         let stunServer = LKRTCIceServer(urlStrings: ["stun:stun.l.google.com:19302"])
@@ -160,17 +161,47 @@ final class WebRTCStreamClient: NSObject {
         }
 
         // Deactivate/activate audio session to restore system volume when muted
-        configureAudioSession(active: enabled)
+        setAudioSessionActive(enabled)
     }
 
-    private func configureAudioSession(active: Bool) {
+    private func setAudioSessionActive(_ active: Bool) {
+        if active {
+            activateAudioSessionIfNeeded()
+        } else {
+            deactivateAudioSessionIfNeeded()
+        }
+    }
+
+    private func activateAudioSessionIfNeeded() {
+        guard !didActivateAudioSession else { return }
+
         let configuration = LKRTCAudioSessionConfiguration.webRTC()
         configuration.categoryOptions.insert(.mixWithOthers)
         LKRTCAudioSessionConfiguration.setWebRTC(configuration)
 
         let audioSession = LKRTCAudioSession.sharedInstance()
         audioSession.lockForConfiguration()
-        try? audioSession.setConfiguration(configuration, active: active)
+        do {
+            try audioSession.setConfiguration(configuration)
+            try audioSession.setActive(true)
+            didActivateAudioSession = true
+        } catch {
+            logger.error("Failed to activate WebRTC audio session: \(error.localizedDescription)")
+        }
+        audioSession.unlockForConfiguration()
+    }
+
+    private func deactivateAudioSessionIfNeeded() {
+        guard didActivateAudioSession else { return }
+
+        let audioSession = LKRTCAudioSession.sharedInstance()
+        audioSession.lockForConfiguration()
+        do {
+            try audioSession.setActive(false)
+            didActivateAudioSession = false
+        } catch {
+            logger.error("Failed to deactivate WebRTC audio session: \(error.localizedDescription)")
+        }
         audioSession.unlockForConfiguration()
     }
 
@@ -183,7 +214,7 @@ final class WebRTCStreamClient: NSObject {
         peerConnection?.close()
         peerConnection = nil
         videoView = nil
-        configureAudioSession(active: false)
+        deactivateAudioSessionIfNeeded()
     }
 
 }

--- a/Itsyhome/iOS/WebRTCStreamClient.swift
+++ b/Itsyhome/iOS/WebRTCStreamClient.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import AVFoundation
 import LiveKitWebRTC
 import os.log
 
@@ -45,6 +46,7 @@ final class WebRTCStreamClient: NSObject {
     func connect(entityId: String, signaling: HACameraSignaling, dataChannelLabel: String? = nil) async throws {
         self.entityId = entityId
         self.signaling = signaling
+        configureAudioSession(active: true)
 
         // Configure ICE servers (STUN only — HA WebRTC typically uses direct connectivity)
         let stunServer = LKRTCIceServer(urlStrings: ["stun:stun.l.google.com:19302"])
@@ -158,13 +160,17 @@ final class WebRTCStreamClient: NSObject {
         }
 
         // Deactivate/activate audio session to restore system volume when muted
+        configureAudioSession(active: enabled)
+    }
+
+    private func configureAudioSession(active: Bool) {
+        let configuration = LKRTCAudioSessionConfiguration.webRTC()
+        configuration.categoryOptions.insert(.mixWithOthers)
+        LKRTCAudioSessionConfiguration.setWebRTC(configuration)
+
         let audioSession = LKRTCAudioSession.sharedInstance()
         audioSession.lockForConfiguration()
-        if enabled {
-            try? audioSession.setActive(true)
-        } else {
-            try? audioSession.setActive(false)
-        }
+        try? audioSession.setConfiguration(configuration, active: active)
         audioSession.unlockForConfiguration()
     }
 
@@ -177,6 +183,7 @@ final class WebRTCStreamClient: NSObject {
         peerConnection?.close()
         peerConnection = nil
         videoView = nil
+        configureAudioSession(active: false)
     }
 
 }


### PR DESCRIPTION
## Summary

Camera streams no longer duck (lower the volume of) other system audio. The stream players now configure their audio session so opening a camera view stops interrupting music, calls, or other playback, and the session is deactivated cleanly when the stream closes.

## Why this matters

Issue #138 reports that viewing a camera ducks system audio: starting an HLS or WebRTC camera stream activated an audio session with default options, so iOS lowered other audio even though these streams are typically muted video. Users watching a camera had their music or podcast volume dropped for no reason.

The stream clients now use a non-ducking audio-session configuration and balance activation with deactivation on teardown. Because `LKRTCAudioSession` (WebRTC) and the AVAudioSession are reference-counted, activation and deactivation are guarded by a per-client `didActivateAudioSession` flag so each client activates at most once and deactivates exactly once. `deinit` routes through the idempotent teardown, so normal `disconnect(); client = nil` flows and stream reopen do not drive the reference count negative or leave the session active.

## Testing

Verified the activation/deactivation is balanced and idempotent by tracing the disconnect and deinit paths and the mute path (which clears the flag after deactivating). On-device build/run was not exercised in this environment (no iOS simulator available); the change is scoped to audio-session setup and teardown in the two stream clients.

Fixes #138
