### PR TITLE
Support half-degree setpoints driven by device metadata

### DIFF
--- a/Itsyhome/HomeAssistant/EntityMapper.swift
+++ b/Itsyhome/HomeAssistant/EntityMapper.swift
@@ -70,6 +70,15 @@ final class EntityMapper {
         return value
     }
 
+    /// Convert a temperature step from HA's unit to Celsius. A step is a
+    /// delta, so it scales by 5/9 without the -32 offset.
+    private func normalizeTemperatureStep(_ value: Double) -> Double {
+        if haTemperatureUnit == "°F" {
+            return value * 5.0 / 9.0
+        }
+        return value
+    }
+
     /// Build reverse lookup caches for fast UUID → entityId lookups
     private func buildCharacteristicCache() {
         characteristicToEntity.removeAll()
@@ -434,6 +443,13 @@ final class EntityMapper {
         // Generate deterministic UUIDs for characteristic IDs
         let entityUUID = deterministicUUID(for: state.entityId)
 
+        // Climate setpoint metadata, normalized to internal Celsius. HA has
+        // one step/min/max set per entity, so the same values feed the target
+        // trio and both threshold trios.
+        let climateStep = state.domain == "climate" ? state.targetTempStep.map { normalizeTemperatureStep($0) } : nil
+        let climateMin = state.domain == "climate" ? state.minTemp.map { normalizeTemperature($0) } : nil
+        let climateMax = state.domain == "climate" ? state.maxTemp.map { normalizeTemperature($0) } : nil
+
         return ServiceData(
             uniqueIdentifier: entityUUID,
             name: state.friendlyName,
@@ -453,6 +469,9 @@ final class EntityMapper {
             // Climate characteristics
             currentTemperatureId: (state.currentTemperature != nil || (state.domain == "sensor" && state.deviceClass == "temperature" && state.numericState != nil)) ? characteristicUUID(state.entityId, "current_temp") : nil,
             targetTemperatureId: state.targetTemperature != nil ? characteristicUUID(state.entityId, "target_temp") : nil,
+            targetTemperatureStep: climateStep,
+            targetTemperatureMin: climateMin,
+            targetTemperatureMax: climateMax,
             heatingCoolingStateId: state.hvacAction != nil ? characteristicUUID(state.entityId, "hvac_action") : nil,
             targetHeatingCoolingStateId: state.domain == "climate" ? characteristicUUID(state.entityId, "hvac_mode") : nil,
             availableHVACModes: state.domain == "climate" ? state.hvacModes : nil,
@@ -474,7 +493,13 @@ final class EntityMapper {
             // HeaterCooler characteristics
             activeId: state.domain == "valve" ? characteristicUUID(state.entityId, "active") : nil,
             coolingThresholdTemperatureId: state.targetTempHigh != nil ? characteristicUUID(state.entityId, "target_temp_high") : nil,
+            coolingThresholdStep: climateStep,
+            coolingThresholdMin: climateMin,
+            coolingThresholdMax: climateMax,
             heatingThresholdTemperatureId: state.targetTempLow != nil ? characteristicUUID(state.entityId, "target_temp_low") : nil,
+            heatingThresholdStep: climateStep,
+            heatingThresholdMin: climateMin,
+            heatingThresholdMax: climateMax,
             // Fan characteristics - only provide speed if fan supports percentage (SET_PERCENTAGE feature)
             rotationSpeedId: state.domain == "fan" && state.supportsPercentage ? characteristicUUID(state.entityId, "speed") : nil,
             rotationSpeedMin: 0,

--- a/Itsyhome/HomeAssistant/HAModels.swift
+++ b/Itsyhome/HomeAssistant/HAModels.swift
@@ -384,6 +384,21 @@ extension HAEntityState {
     var swingModes: [String] {
         attributes["swing_modes"] as? [String] ?? []
     }
+
+    /// Target temperature step (e.g. 0.5)
+    var targetTempStep: Double? {
+        attributes["target_temp_step"] as? Double
+    }
+
+    /// Minimum target temperature
+    var minTemp: Double? {
+        attributes["min_temp"] as? Double
+    }
+
+    /// Maximum target temperature
+    var maxTemp: Double? {
+        attributes["max_temp"] as? Double
+    }
 }
 
 // MARK: - Cover attributes

--- a/Itsyhome/Shared/BridgeProtocols.swift
+++ b/Itsyhome/Shared/BridgeProtocols.swift
@@ -65,6 +65,9 @@ public struct ServiceData: Codable {
     public let colorTemperatureMax: Double?    // Max Mired value
     public let currentTemperatureId: String?   // Thermostats, temperature sensors, AC
     public let targetTemperatureId: String?    // Thermostats
+    public let targetTemperatureStep: Double?  // Step value (°C)
+    public let targetTemperatureMin: Double?   // Min value (°C)
+    public let targetTemperatureMax: Double?   // Max value (°C)
     public let heatingCoolingStateId: String?  // Thermostats (current mode)
     public let targetHeatingCoolingStateId: String? // Thermostats (target mode)
     public let validTargetHeatingCoolingStates: [Int]?  // Valid values for target state (e.g. [0, 1] = off + heat)
@@ -86,7 +89,13 @@ public struct ServiceData: Codable {
     public let targetHeaterCoolerStateId: String?   // AC target mode (auto/heat/cool)
     public let validTargetHeaterCoolerStates: [Int]?  // Valid values for target state (e.g. [1] = heat only)
     public let coolingThresholdTemperatureId: String?  // AC cooling target temp
+    public let coolingThresholdStep: Double?           // Step value (°C)
+    public let coolingThresholdMin: Double?            // Min value (°C)
+    public let coolingThresholdMax: Double?            // Max value (°C)
     public let heatingThresholdTemperatureId: String?  // AC heating target temp
+    public let heatingThresholdStep: Double?           // Step value (°C)
+    public let heatingThresholdMin: Double?            // Min value (°C)
+    public let heatingThresholdMax: Double?            // Max value (°C)
     // Fan characteristics
     public let rotationSpeedId: String?        // Fan speed
     public let rotationSpeedMin: Double?       // Min speed value
@@ -161,6 +170,9 @@ public struct ServiceData: Codable {
         colorTemperatureMax: Double? = nil,
         currentTemperatureId: UUID? = nil,
         targetTemperatureId: UUID? = nil,
+        targetTemperatureStep: Double? = nil,
+        targetTemperatureMin: Double? = nil,
+        targetTemperatureMax: Double? = nil,
         heatingCoolingStateId: UUID? = nil,
         targetHeatingCoolingStateId: UUID? = nil,
         validTargetHeatingCoolingStates: [Int]? = nil,
@@ -181,7 +193,13 @@ public struct ServiceData: Codable {
         targetHeaterCoolerStateId: UUID? = nil,
         validTargetHeaterCoolerStates: [Int]? = nil,
         coolingThresholdTemperatureId: UUID? = nil,
+        coolingThresholdStep: Double? = nil,
+        coolingThresholdMin: Double? = nil,
+        coolingThresholdMax: Double? = nil,
         heatingThresholdTemperatureId: UUID? = nil,
+        heatingThresholdStep: Double? = nil,
+        heatingThresholdMin: Double? = nil,
+        heatingThresholdMax: Double? = nil,
         rotationSpeedId: UUID? = nil,
         rotationSpeedMin: Double? = nil,
         rotationSpeedMax: Double? = nil,
@@ -252,6 +270,9 @@ public struct ServiceData: Codable {
         self.colorTemperatureMax = colorTemperatureMax
         self.currentTemperatureId = currentTemperatureId?.uuidString
         self.targetTemperatureId = targetTemperatureId?.uuidString
+        self.targetTemperatureStep = targetTemperatureStep
+        self.targetTemperatureMin = targetTemperatureMin
+        self.targetTemperatureMax = targetTemperatureMax
         self.heatingCoolingStateId = heatingCoolingStateId?.uuidString
         self.targetHeatingCoolingStateId = targetHeatingCoolingStateId?.uuidString
         self.validTargetHeatingCoolingStates = validTargetHeatingCoolingStates
@@ -272,7 +293,13 @@ public struct ServiceData: Codable {
         self.targetHeaterCoolerStateId = targetHeaterCoolerStateId?.uuidString
         self.validTargetHeaterCoolerStates = validTargetHeaterCoolerStates
         self.coolingThresholdTemperatureId = coolingThresholdTemperatureId?.uuidString
+        self.coolingThresholdStep = coolingThresholdStep
+        self.coolingThresholdMin = coolingThresholdMin
+        self.coolingThresholdMax = coolingThresholdMax
         self.heatingThresholdTemperatureId = heatingThresholdTemperatureId?.uuidString
+        self.heatingThresholdStep = heatingThresholdStep
+        self.heatingThresholdMin = heatingThresholdMin
+        self.heatingThresholdMax = heatingThresholdMax
         self.rotationSpeedId = rotationSpeedId?.uuidString
         self.rotationSpeedMin = rotationSpeedMin
         self.rotationSpeedMax = rotationSpeedMax

--- a/Itsyhome/iOS/HomeKitManager+DataFetching.swift
+++ b/Itsyhome/iOS/HomeKitManager+DataFetching.swift
@@ -344,6 +344,25 @@ extension HomeKitManager {
         let colorTempMin = colorTempChar?.metadata?.minimumValue?.doubleValue
         let colorTempMax = colorTempChar?.metadata?.maximumValue?.doubleValue
 
+        // Get target temperature step/min/max from metadata (thermostats)
+        let targetTempChar = findChar(HMCharacteristicTypeTargetTemperature)
+        let targetTempStep = targetTempChar?.metadata?.stepValue?.doubleValue
+        let targetTempMin = targetTempChar?.metadata?.minimumValue?.doubleValue
+        let targetTempMax = targetTempChar?.metadata?.maximumValue?.doubleValue
+
+        // Get heating threshold step/min/max from metadata (heater-coolers and
+        // auto-mode thermostats; heat-only devices like Eve Thermo carry only this one)
+        let heatingThresholdChar = findChar(CharacteristicTypes.heatingThresholdTemperature)
+        let heatingThresholdStep = heatingThresholdChar?.metadata?.stepValue?.doubleValue
+        let heatingThresholdMin = heatingThresholdChar?.metadata?.minimumValue?.doubleValue
+        let heatingThresholdMax = heatingThresholdChar?.metadata?.maximumValue?.doubleValue
+
+        // Get cooling threshold step/min/max from metadata
+        let coolingThresholdChar = findChar(CharacteristicTypes.coolingThresholdTemperature)
+        let coolingThresholdStep = coolingThresholdChar?.metadata?.stepValue?.doubleValue
+        let coolingThresholdMin = coolingThresholdChar?.metadata?.minimumValue?.doubleValue
+        let coolingThresholdMax = coolingThresholdChar?.metadata?.maximumValue?.doubleValue
+
         // Get valve type value (stored directly, not as characteristic ID)
         let valveTypeChar = findChar(CharacteristicTypes.valveType)
         let valveTypeValue = valveTypeChar?.value as? Int
@@ -375,6 +394,9 @@ extension HomeKitManager {
             colorTemperatureMax: colorTempMax,
             currentTemperatureId: charId(HMCharacteristicTypeCurrentTemperature),
             targetTemperatureId: charId(HMCharacteristicTypeTargetTemperature),
+            targetTemperatureStep: targetTempStep,
+            targetTemperatureMin: targetTempMin,
+            targetTemperatureMax: targetTempMax,
             heatingCoolingStateId: charId(HMCharacteristicTypeCurrentHeatingCooling),
             targetHeatingCoolingStateId: charId(HMCharacteristicTypeTargetHeatingCooling),
             validTargetHeatingCoolingStates: validHCoolingStates,
@@ -395,7 +417,13 @@ extension HomeKitManager {
             targetHeaterCoolerStateId: charId(CharacteristicTypes.targetHeaterCoolerState),
             validTargetHeaterCoolerStates: validHCStates,
             coolingThresholdTemperatureId: charId(CharacteristicTypes.coolingThresholdTemperature),
+            coolingThresholdStep: coolingThresholdStep,
+            coolingThresholdMin: coolingThresholdMin,
+            coolingThresholdMax: coolingThresholdMax,
             heatingThresholdTemperatureId: charId(CharacteristicTypes.heatingThresholdTemperature),
+            heatingThresholdStep: heatingThresholdStep,
+            heatingThresholdMin: heatingThresholdMin,
+            heatingThresholdMax: heatingThresholdMax,
             // Fan characteristics
             rotationSpeedId: charId(CharacteristicTypes.rotationSpeed),
             rotationSpeedMin: rotationSpeedMin,

--- a/macOSBridge/DebugMockAccessories.swift
+++ b/macOSBridge/DebugMockAccessories.swift
@@ -138,10 +138,19 @@ enum DebugMockups {
                 roomIdentifier: nil,
                 currentTemperatureId: UUID(),
                 targetTemperatureId: UUID(),
+                targetTemperatureStep: 0.5,
+                targetTemperatureMin: 10,
+                targetTemperatureMax: 30,
                 heatingCoolingStateId: UUID(),
                 targetHeatingCoolingStateId: UUID(),
                 coolingThresholdTemperatureId: UUID(),
-                heatingThresholdTemperatureId: UUID()
+                coolingThresholdStep: 0.5,
+                coolingThresholdMin: 10,
+                coolingThresholdMax: 30,
+                heatingThresholdTemperatureId: UUID(),
+                heatingThresholdStep: 0.5,
+                heatingThresholdMin: 10,
+                heatingThresholdMax: 30
             ),
             ServiceData(
                 uniqueIdentifier: UUID(),
@@ -154,7 +163,13 @@ enum DebugMockups {
                 currentHeaterCoolerStateId: UUID(),
                 targetHeaterCoolerStateId: UUID(),
                 coolingThresholdTemperatureId: UUID(),
+                coolingThresholdStep: 0.5,
+                coolingThresholdMin: 16,
+                coolingThresholdMax: 30,
                 heatingThresholdTemperatureId: UUID(),
+                heatingThresholdStep: 0.5,
+                heatingThresholdMin: 16,
+                heatingThresholdMax: 30,
                 swingModeId: UUID()
             ),
             ServiceData(
@@ -168,7 +183,10 @@ enum DebugMockups {
                 currentHeaterCoolerStateId: UUID(),
                 targetHeaterCoolerStateId: UUID(),
                 validTargetHeaterCoolerStates: [1],
-                heatingThresholdTemperatureId: UUID()
+                heatingThresholdTemperatureId: UUID(),
+                heatingThresholdStep: 0.5,
+                heatingThresholdMin: 16,
+                heatingThresholdMax: 30
             ),
             ServiceData(
                 uniqueIdentifier: UUID(),
@@ -178,6 +196,9 @@ enum DebugMockups {
                 roomIdentifier: nil,
                 currentTemperatureId: UUID(),
                 targetTemperatureId: UUID(),
+                targetTemperatureStep: 0.5,
+                targetTemperatureMin: 10,
+                targetTemperatureMax: 30,
                 heatingCoolingStateId: UUID(),
                 targetHeatingCoolingStateId: UUID(),
                 validTargetHeatingCoolingStates: [0, 1]

--- a/macOSBridge/MenuItems/ACMenuItem.swift
+++ b/macOSBridge/MenuItems/ACMenuItem.swift
@@ -28,6 +28,15 @@ class ACMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefreshable
     private var heatingThreshold: Double = 20
     private var swingMode: Int = 0     // 0=DISABLED, 1=ENABLED
 
+    // Device-advertised setpoint metadata; steps are derived through
+    // TemperatureFormatter.uiStep so missing metadata keeps whole degrees
+    private let heatingThresholdStep: Double
+    private let heatingThresholdMin: Double?
+    private let heatingThresholdMax: Double?
+    private let coolingThresholdStep: Double
+    private let coolingThresholdMin: Double?
+    private let coolingThresholdMax: Double?
+
     private let containerView: HighlightingMenuItemView
     private let iconView: NSImageView
     private let nameLabel: NSTextField
@@ -91,6 +100,14 @@ class ACMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefreshable
         self.heatingThresholdId = serviceData.heatingThresholdTemperatureId?.uuid
         self.swingModeId = serviceData.swingModeId?.uuid
         self.hasThresholds = coolingThresholdId != nil && heatingThresholdId != nil
+
+        // Per-characteristic setpoint metadata (0.5 °C devices)
+        self.heatingThresholdStep = TemperatureFormatter.uiStep(serviceData.heatingThresholdStep)
+        self.heatingThresholdMin = serviceData.heatingThresholdMin
+        self.heatingThresholdMax = serviceData.heatingThresholdMax
+        self.coolingThresholdStep = TemperatureFormatter.uiStep(serviceData.coolingThresholdStep)
+        self.coolingThresholdMin = serviceData.coolingThresholdMin
+        self.coolingThresholdMax = serviceData.coolingThresholdMax
 
         // Determine valid modes: all 3 by default, or filtered by validValues
         let allModes = serviceData.validTargetHeaterCoolerStates ?? [0, 1, 2]
@@ -166,9 +183,11 @@ class ACMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefreshable
         controlsRow = NSView(frame: NSRect(x: 0, y: DS.Spacing.sm, width: DS.ControlSize.menuItemWidth, height: 26))
         controlsRow.isHidden = true
 
-        // Mode buttons container
+        // Mode buttons container. 34 pt buttons (36 elsewhere) free the width
+        // the widened Auto-mode range control needs; "Cool"/"Heat"/"Auto" and
+        // their localizations still fit, measured at the 10 pt button font
         let modeCount = validModes.count
-        let containerWidth = ModeButtonGroup.widthForButtons(count: max(modeCount, 1))
+        let containerWidth = ModeButtonGroup.widthForButtons(count: max(modeCount, 1), buttonWidth: 34)
         let modeContainer = ModeButtonGroup(frame: NSRect(x: labelX, y: 3, width: containerWidth, height: 22))
 
         if validModes.contains(2) {
@@ -192,7 +211,7 @@ class ACMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefreshable
             targetState = firstMode
         }
 
-        // Single temperature control: [−] 24° [+]
+        // Single temperature control: [−] 24° [+] (32 pt label holds "21.5°")
         let singleTempX = DS.ControlSize.menuItemWidth - DS.Spacing.md - 78
         singleTempContainer = NSView(frame: NSRect(x: singleTempX, y: 0, width: 78, height: 26))
 
@@ -213,12 +232,21 @@ class ACMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefreshable
 
         controlsRow.addSubview(singleTempContainer)
 
-        // Range temperature control: -20+ -24+ (for Auto mode with thresholds)
+        // Range temperature control: -20+ -24+ (for Auto mode with thresholds).
+        // Labels are 32 pt so every half-degree string through "34.5°" clears
+        // NSTextField's roughly 3 pt of cell insets; the stepper gap and right
+        // margin shrink to 4 so the control (x 144) clears the 34 pt-button
+        // mode group ending at x 140. Tradeoff: the right edge lands at 256,
+        // 8 pt past the 248 trailing edge shared by the power toggle and the
+        // single stepper, flush with the hover highlight's 4 pt inset;
+        // accepted over overlapping the mode group. HAClimateMenuItem's range
+        // control keeps the 12 pt margin and the 248 edge, so the two Auto
+        // layouts intentionally differ.
         let miniBtn: CGFloat = 11
-        let miniLabel: CGFloat = 24
-        let miniStepper = miniBtn + miniLabel + miniBtn  // 46
-        let rangeWidth = miniStepper * 2 + 6  // 98
-        let rangeTempX = DS.ControlSize.menuItemWidth - DS.Spacing.md - rangeWidth
+        let miniLabel: CGFloat = 32
+        let miniStepper = miniBtn + miniLabel + miniBtn  // 54
+        let rangeWidth = miniStepper * 2 + 4  // 112
+        let rangeTempX = DS.ControlSize.menuItemWidth - DS.Spacing.xs - rangeWidth
         rangeTempContainer = NSView(frame: NSRect(x: rangeTempX, y: 1, width: rangeWidth, height: 26))
         rangeTempContainer.isHidden = true
 
@@ -239,7 +267,7 @@ class ACMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefreshable
         rangeTempContainer.addSubview(heatPlusButton)
 
         // Cool stepper (right): -24+
-        let coolX = miniStepper + 6
+        let coolX = miniStepper + 4
         coolMinusButton = StepperButton.create(title: "−", size: .mini)
         coolMinusButton.frame.origin = NSPoint(x: coolX, y: 8)
         rangeTempContainer.addSubview(coolMinusButton)
@@ -344,13 +372,13 @@ class ACMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefreshable
         } else if characteristicId == coolingThresholdId {
             if let temp = ValueConversion.toDouble(value) {
                 coolingThreshold = temp
-                coolLabel.stringValue = TemperatureFormatter.format(temp)
+                coolLabel.stringValue = TemperatureFormatter.formatSetpoint(temp)
                 updateTargetDisplay()
             }
         } else if characteristicId == heatingThresholdId {
             if let temp = ValueConversion.toDouble(value) {
                 heatingThreshold = temp
-                heatLabel.stringValue = TemperatureFormatter.format(temp)
+                heatLabel.stringValue = TemperatureFormatter.formatSetpoint(temp)
                 updateTargetDisplay()
             }
         } else if characteristicId == swingModeId {
@@ -421,7 +449,7 @@ class ACMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefreshable
         case 2: targetTemp = coolingThreshold  // cool mode
         default: targetTemp = coolingThreshold // auto - show cooling threshold
         }
-        targetLabel.stringValue = TemperatureFormatter.format(targetTemp)
+        targetLabel.stringValue = TemperatureFormatter.formatSetpoint(targetTemp)
     }
 
     private func currentTargetTemp() -> Double {
@@ -432,17 +460,24 @@ class ACMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefreshable
         }
     }
 
-    private func setTargetTemp(_ temp: Double) {
-        let clamped = min(max(temp, 16), 30)
+    private func currentTargetStep() -> Double {
+        switch targetState {
+        case 1: return heatingThresholdStep
+        default: return coolingThresholdStep
+        }
+    }
 
+    private func setTargetTemp(_ temp: Double) {
         switch targetState {
         case 1: // heat mode
+            let clamped = min(max(temp, heatingThresholdMin ?? 16), heatingThresholdMax ?? 30)
             heatingThreshold = clamped
             if let id = heatingThresholdId {
                 bridge?.writeCharacteristic(identifier: id, value: Float(clamped))
                 notifyLocalChange(characteristicId: id, value: Float(clamped))
             }
         default: // cool or auto
+            let clamped = min(max(temp, coolingThresholdMin ?? 16), coolingThresholdMax ?? 30)
             coolingThreshold = clamped
             if let id = coolingThresholdId {
                 bridge?.writeCharacteristic(identifier: id, value: Float(clamped))
@@ -477,11 +512,13 @@ class ACMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefreshable
     }
 
     @objc private func decreaseTemp(_ sender: NSButton) {
-        setTargetTemp(currentTargetTemp() - 1)
+        // Step through TemperatureFormatter so Fahrenheit mode moves one
+        // displayed °F, not a raw 1 °C (1.8 °F) jump
+        setTargetTemp(TemperatureFormatter.step(currentTargetTemp(), by: -1, step: currentTargetStep()))
     }
 
     @objc private func increaseTemp(_ sender: NSButton) {
-        setTargetTemp(currentTargetTemp() + 1)
+        setTargetTemp(TemperatureFormatter.step(currentTargetTemp(), by: 1, step: currentTargetStep()))
     }
 
     @objc private func swingTapped(_ sender: NSButton) {
@@ -500,10 +537,12 @@ class ACMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefreshable
     // MARK: - Threshold controls (Auto mode)
 
     private func setHeatingThreshold(_ temp: Double) {
-        let maxHeat = coolingThreshold - 1
-        let clamped = min(max(temp, 16), maxHeat)
+        // The 1 °C gap below the cooling threshold stays even on half-degree
+        // devices; some devices reject writes with a smaller spread
+        let maxHeat = min(coolingThreshold - 1, heatingThresholdMax ?? .infinity)
+        let clamped = min(max(temp, heatingThresholdMin ?? 16), maxHeat)
         heatingThreshold = clamped
-        heatLabel.stringValue = TemperatureFormatter.format(clamped)
+        heatLabel.stringValue = TemperatureFormatter.formatSetpoint(clamped)
         if let id = heatingThresholdId {
             bridge?.writeCharacteristic(identifier: id, value: Float(clamped))
             notifyLocalChange(characteristicId: id, value: Float(clamped))
@@ -511,10 +550,10 @@ class ACMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefreshable
     }
 
     private func setCoolingThreshold(_ temp: Double) {
-        let minCool = heatingThreshold + 1
-        let clamped = min(max(temp, minCool), 30)
+        let minCool = max(heatingThreshold + 1, coolingThresholdMin ?? -Double.infinity)
+        let clamped = min(max(temp, minCool), coolingThresholdMax ?? 30)
         coolingThreshold = clamped
-        coolLabel.stringValue = TemperatureFormatter.format(clamped)
+        coolLabel.stringValue = TemperatureFormatter.formatSetpoint(clamped)
         if let id = coolingThresholdId {
             bridge?.writeCharacteristic(identifier: id, value: Float(clamped))
             notifyLocalChange(characteristicId: id, value: Float(clamped))
@@ -522,18 +561,18 @@ class ACMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefreshable
     }
 
     @objc private func decreaseHeatThreshold(_ sender: NSButton) {
-        setHeatingThreshold(heatingThreshold - 1)
+        setHeatingThreshold(TemperatureFormatter.step(heatingThreshold, by: -1, step: heatingThresholdStep))
     }
 
     @objc private func increaseHeatThreshold(_ sender: NSButton) {
-        setHeatingThreshold(heatingThreshold + 1)
+        setHeatingThreshold(TemperatureFormatter.step(heatingThreshold, by: 1, step: heatingThresholdStep))
     }
 
     @objc private func decreaseCoolThreshold(_ sender: NSButton) {
-        setCoolingThreshold(coolingThreshold - 1)
+        setCoolingThreshold(TemperatureFormatter.step(coolingThreshold, by: -1, step: coolingThresholdStep))
     }
 
     @objc private func increaseCoolThreshold(_ sender: NSButton) {
-        setCoolingThreshold(coolingThreshold + 1)
+        setCoolingThreshold(TemperatureFormatter.step(coolingThreshold, by: 1, step: coolingThresholdStep))
     }
 }

--- a/macOSBridge/MenuItems/HAClimateMenuItem.swift
+++ b/macOSBridge/MenuItems/HAClimateMenuItem.swift
@@ -28,6 +28,18 @@ class HAClimateMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefr
     private var heatingThreshold: Double = 18
     private var swingMode: Int = 0         // 0=off, 1=auto
 
+    // Device-advertised setpoint metadata; steps are derived through
+    // TemperatureFormatter.uiStep so missing metadata keeps whole degrees
+    private let targetTempStep: Double
+    private let targetTempMin: Double?
+    private let targetTempMax: Double?
+    private let heatingThresholdStep: Double
+    private let heatingThresholdMin: Double?
+    private let heatingThresholdMax: Double?
+    private let coolingThresholdStep: Double
+    private let coolingThresholdMin: Double?
+    private let coolingThresholdMax: Double?
+
     private let containerView: HighlightingMenuItemView
     private let iconView: NSImageView
     private let nameLabel: NSTextField
@@ -101,6 +113,17 @@ class HAClimateMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefr
         let showSwing = swingModes.isEmpty || swingModes.contains("off")
         self.swingModeId = showSwing ? serviceData.swingModeId?.uuid : nil
         self.hasThresholds = coolingThresholdId != nil && heatingThresholdId != nil
+
+        // Per-characteristic setpoint metadata (0.5 °C devices)
+        self.targetTempStep = TemperatureFormatter.uiStep(serviceData.targetTemperatureStep)
+        self.targetTempMin = serviceData.targetTemperatureMin
+        self.targetTempMax = serviceData.targetTemperatureMax
+        self.heatingThresholdStep = TemperatureFormatter.uiStep(serviceData.heatingThresholdStep)
+        self.heatingThresholdMin = serviceData.heatingThresholdMin
+        self.heatingThresholdMax = serviceData.heatingThresholdMax
+        self.coolingThresholdStep = TemperatureFormatter.uiStep(serviceData.coolingThresholdStep)
+        self.coolingThresholdMin = serviceData.coolingThresholdMin
+        self.coolingThresholdMax = serviceData.coolingThresholdMax
 
         // Determine if we need 3 rows (4+ mode buttons) or should hide mode selector (1 mode)
         let modes = serviceData.availableHVACModes ?? []
@@ -228,9 +251,9 @@ class HAClimateMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefr
 
         // Range temperature control: -18+ -24+ (for Auto mode with thresholds)
         let smallBtn: CGFloat = 16
-        let smallLabel: CGFloat = 28
-        let smallStepper = smallBtn + smallLabel + smallBtn  // 60
-        let rangeWidth = smallStepper * 2 + 6  // 126
+        let smallLabel: CGFloat = 32  // Wide enough for a half degree ("21.5°")
+        let smallStepper = smallBtn + smallLabel + smallBtn  // 64
+        let rangeWidth = smallStepper * 2 + 6  // 134
         let rangeTempX = DS.ControlSize.menuItemWidth - DS.Spacing.md - rangeWidth
         rangeTempContainer = NSView(frame: NSRect(x: rangeTempX, y: singleTempParentY, width: rangeWidth, height: 26))
         rangeTempContainer.isHidden = true
@@ -399,7 +422,7 @@ class HAClimateMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefr
         } else if characteristicId == targetTempId {
             if let temp = ValueConversion.toDouble(value) {
                 targetTemp = temp
-                targetLabel.stringValue = TemperatureFormatter.format(temp)
+                targetLabel.stringValue = TemperatureFormatter.formatSetpoint(temp)
             }
         } else if characteristicId == currentStateId {
             if let state = ValueConversion.toInt(value) {
@@ -432,12 +455,12 @@ class HAClimateMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefr
         } else if characteristicId == coolingThresholdId {
             if let temp = ValueConversion.toDouble(value) {
                 coolingThreshold = temp
-                coolLabel.stringValue = TemperatureFormatter.format(temp)
+                coolLabel.stringValue = TemperatureFormatter.formatSetpoint(temp)
             }
         } else if characteristicId == heatingThresholdId {
             if let temp = ValueConversion.toDouble(value) {
                 heatingThreshold = temp
-                heatLabel.stringValue = TemperatureFormatter.format(temp)
+                heatLabel.stringValue = TemperatureFormatter.formatSetpoint(temp)
             }
         } else if characteristicId == swingModeId {
             if let mode = ValueConversion.toInt(value) {
@@ -584,9 +607,9 @@ class HAClimateMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefr
     }
 
     private func setTargetTemp(_ temp: Double) {
-        let clamped = min(max(temp, 10), 30)
+        let clamped = min(max(temp, targetTempMin ?? 10), targetTempMax ?? 30)
         targetTemp = clamped
-        targetLabel.stringValue = TemperatureFormatter.format(clamped)
+        targetLabel.stringValue = TemperatureFormatter.formatSetpoint(clamped)
         if let id = targetTempId {
             bridge?.writeCharacteristic(identifier: id, value: Float(clamped))
             notifyLocalChange(characteristicId: id, value: Float(clamped))
@@ -607,20 +630,22 @@ class HAClimateMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefr
     }
 
     @objc private func decreaseTemp(_ sender: NSButton) {
-        setTargetTemp(TemperatureFormatter.step(targetTemp, by: -1))
+        setTargetTemp(TemperatureFormatter.step(targetTemp, by: -1, step: targetTempStep))
     }
 
     @objc private func increaseTemp(_ sender: NSButton) {
-        setTargetTemp(TemperatureFormatter.step(targetTemp, by: 1))
+        setTargetTemp(TemperatureFormatter.step(targetTemp, by: 1, step: targetTempStep))
     }
 
     // MARK: - Threshold controls (Auto mode)
 
     private func setHeatingThreshold(_ temp: Double) {
-        let maxHeat = coolingThreshold - 1
-        let clamped = min(max(temp, 10), maxHeat)
+        // The 1 °C gap below the cooling threshold stays even on half-degree
+        // devices; some devices reject writes with a smaller spread
+        let maxHeat = min(coolingThreshold - 1, heatingThresholdMax ?? .infinity)
+        let clamped = min(max(temp, heatingThresholdMin ?? 10), maxHeat)
         heatingThreshold = clamped
-        heatLabel.stringValue = TemperatureFormatter.format(clamped)
+        heatLabel.stringValue = TemperatureFormatter.formatSetpoint(clamped)
         if let id = heatingThresholdId {
             bridge?.writeCharacteristic(identifier: id, value: Float(clamped))
             notifyLocalChange(characteristicId: id, value: Float(clamped))
@@ -628,10 +653,10 @@ class HAClimateMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefr
     }
 
     private func setCoolingThreshold(_ temp: Double) {
-        let minCool = heatingThreshold + 1
-        let clamped = min(max(temp, minCool), 30)
+        let minCool = max(heatingThreshold + 1, coolingThresholdMin ?? -Double.infinity)
+        let clamped = min(max(temp, minCool), coolingThresholdMax ?? 30)
         coolingThreshold = clamped
-        coolLabel.stringValue = TemperatureFormatter.format(clamped)
+        coolLabel.stringValue = TemperatureFormatter.formatSetpoint(clamped)
         if let id = coolingThresholdId {
             bridge?.writeCharacteristic(identifier: id, value: Float(clamped))
             notifyLocalChange(characteristicId: id, value: Float(clamped))
@@ -639,19 +664,19 @@ class HAClimateMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRefr
     }
 
     @objc private func decreaseHeatThreshold(_ sender: NSButton) {
-        setHeatingThreshold(TemperatureFormatter.step(heatingThreshold, by: -1))
+        setHeatingThreshold(TemperatureFormatter.step(heatingThreshold, by: -1, step: heatingThresholdStep))
     }
 
     @objc private func increaseHeatThreshold(_ sender: NSButton) {
-        setHeatingThreshold(TemperatureFormatter.step(heatingThreshold, by: 1))
+        setHeatingThreshold(TemperatureFormatter.step(heatingThreshold, by: 1, step: heatingThresholdStep))
     }
 
     @objc private func decreaseCoolThreshold(_ sender: NSButton) {
-        setCoolingThreshold(TemperatureFormatter.step(coolingThreshold, by: -1))
+        setCoolingThreshold(TemperatureFormatter.step(coolingThreshold, by: -1, step: coolingThresholdStep))
     }
 
     @objc private func increaseCoolThreshold(_ sender: NSButton) {
-        setCoolingThreshold(TemperatureFormatter.step(coolingThreshold, by: 1))
+        setCoolingThreshold(TemperatureFormatter.step(coolingThreshold, by: 1, step: coolingThresholdStep))
     }
 
     // MARK: - Swing mode

--- a/macOSBridge/MenuItems/ThermostatMenuItem.swift
+++ b/macOSBridge/MenuItems/ThermostatMenuItem.swift
@@ -26,6 +26,18 @@ class ThermostatMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRef
     private var coolingThreshold: Double = 24
     private var heatingThreshold: Double = 18
 
+    // Device-advertised setpoint metadata; steps are derived through
+    // TemperatureFormatter.uiStep so missing metadata keeps whole degrees
+    private let targetTempStep: Double
+    private let targetTempMin: Double?
+    private let targetTempMax: Double?
+    private let heatingThresholdStep: Double
+    private let heatingThresholdMin: Double?
+    private let heatingThresholdMax: Double?
+    private let coolingThresholdStep: Double
+    private let coolingThresholdMin: Double?
+    private let coolingThresholdMax: Double?
+
     private let containerView: HighlightingMenuItemView
     private let iconView: NSImageView
     private let nameLabel: NSTextField
@@ -89,6 +101,17 @@ class ThermostatMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRef
         self.heatingThresholdId = serviceData.heatingThresholdTemperatureId?.uuid
         self.hasThresholds = coolingThresholdId != nil && heatingThresholdId != nil
 
+        // Per-characteristic setpoint metadata (0.5 °C devices like Eve Thermo)
+        self.targetTempStep = TemperatureFormatter.uiStep(serviceData.targetTemperatureStep)
+        self.targetTempMin = serviceData.targetTemperatureMin
+        self.targetTempMax = serviceData.targetTemperatureMax
+        self.heatingThresholdStep = TemperatureFormatter.uiStep(serviceData.heatingThresholdStep)
+        self.heatingThresholdMin = serviceData.heatingThresholdMin
+        self.heatingThresholdMax = serviceData.heatingThresholdMax
+        self.coolingThresholdStep = TemperatureFormatter.uiStep(serviceData.coolingThresholdStep)
+        self.coolingThresholdMin = serviceData.coolingThresholdMin
+        self.coolingThresholdMax = serviceData.coolingThresholdMax
+
         // Determine valid active modes: filter out off (0), default to all 3
         let allStates = serviceData.validTargetHeatingCoolingStates ?? [0, 1, 2, 3]
         self.activeModes = allStates.filter { $0 != 0 }
@@ -150,9 +173,11 @@ class ThermostatMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRef
         controlsRow = NSView(frame: NSRect(x: 0, y: DS.Spacing.sm, width: DS.ControlSize.menuItemWidth, height: 26))
         controlsRow.isHidden = true
 
-        // Mode buttons container
+        // Mode buttons container. 34 pt buttons (36 elsewhere) free the width
+        // the widened Auto-mode range control needs; "Cool"/"Heat"/"Auto" and
+        // their localizations still fit, measured at the 10 pt button font
         let modeCount = activeModes.count
-        let containerWidth = ModeButtonGroup.widthForButtons(count: max(modeCount, 1))
+        let containerWidth = ModeButtonGroup.widthForButtons(count: max(modeCount, 1), buttonWidth: 34)
         let modeContainer = ModeButtonGroup(frame: NSRect(x: labelX, y: 3, width: containerWidth, height: 22))
 
         if activeModes.contains(2) {
@@ -179,7 +204,7 @@ class ThermostatMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRef
             lastActiveMode = firstActive
         }
 
-        // Single temperature control: [−] 20° [+]
+        // Single temperature control: [−] 20° [+] (32 pt label holds "21.5°")
         let singleTempX = DS.ControlSize.menuItemWidth - DS.Spacing.md - 78
         singleTempContainer = NSView(frame: NSRect(x: singleTempX, y: 0, width: 78, height: 26))
 
@@ -200,12 +225,21 @@ class ThermostatMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRef
 
         controlsRow.addSubview(singleTempContainer)
 
-        // Range temperature control: -18+ -24+ (for Auto mode with thresholds)
+        // Range temperature control: -18+ -24+ (for Auto mode with thresholds).
+        // Labels are 32 pt so every half-degree string through "34.5°" clears
+        // NSTextField's roughly 3 pt of cell insets; the stepper gap and right
+        // margin shrink to 4 so the control (x 144) clears the 34 pt-button
+        // mode group ending at x 140. Tradeoff: the right edge lands at 256,
+        // 8 pt past the 248 trailing edge shared by the power toggle and the
+        // single stepper, flush with the hover highlight's 4 pt inset;
+        // accepted over overlapping the mode group. HAClimateMenuItem's range
+        // control keeps the 12 pt margin and the 248 edge, so the two Auto
+        // layouts intentionally differ.
         let miniBtn: CGFloat = 11
-        let miniLabel: CGFloat = 24
-        let miniStepper = miniBtn + miniLabel + miniBtn  // 44
-        let rangeWidth = miniStepper * 2 + 6  // 94
-        let rangeTempX = DS.ControlSize.menuItemWidth - DS.Spacing.md - rangeWidth
+        let miniLabel: CGFloat = 32
+        let miniStepper = miniBtn + miniLabel + miniBtn  // 54
+        let rangeWidth = miniStepper * 2 + 4  // 112
+        let rangeTempX = DS.ControlSize.menuItemWidth - DS.Spacing.xs - rangeWidth
         rangeTempContainer = NSView(frame: NSRect(x: rangeTempX, y: 1, width: rangeWidth, height: 26))
         rangeTempContainer.isHidden = true
 
@@ -226,7 +260,7 @@ class ThermostatMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRef
         rangeTempContainer.addSubview(heatPlusButton)
 
         // Cool stepper (right): -24+
-        let coolX = miniStepper + 6
+        let coolX = miniStepper + 4
         coolMinusButton = StepperButton.create(title: "−", size: .mini)
         coolMinusButton.frame.origin = NSPoint(x: coolX, y: 8)
         rangeTempContainer.addSubview(coolMinusButton)
@@ -302,7 +336,7 @@ class ThermostatMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRef
         } else if characteristicId == targetTempId {
             if let temp = ValueConversion.toDouble(value) {
                 targetTemp = temp
-                targetLabel.stringValue = TemperatureFormatter.format(temp)
+                targetLabel.stringValue = TemperatureFormatter.formatSetpoint(temp)
             }
         } else if characteristicId == currentStateId {
             if let state = ValueConversion.toInt(value) {
@@ -321,12 +355,12 @@ class ThermostatMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRef
         } else if characteristicId == coolingThresholdId {
             if let temp = ValueConversion.toDouble(value) {
                 coolingThreshold = temp
-                coolLabel.stringValue = TemperatureFormatter.format(temp)
+                coolLabel.stringValue = TemperatureFormatter.formatSetpoint(temp)
             }
         } else if characteristicId == heatingThresholdId {
             if let temp = ValueConversion.toDouble(value) {
                 heatingThreshold = temp
-                heatLabel.stringValue = TemperatureFormatter.format(temp)
+                heatLabel.stringValue = TemperatureFormatter.formatSetpoint(temp)
             }
         }
     }
@@ -406,9 +440,9 @@ class ThermostatMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRef
     }
 
     private func setTargetTemp(_ temp: Double) {
-        let clamped = min(max(temp, 10), 30)
+        let clamped = min(max(temp, targetTempMin ?? 10), targetTempMax ?? 30)
         targetTemp = clamped
-        targetLabel.stringValue = TemperatureFormatter.format(clamped)
+        targetLabel.stringValue = TemperatureFormatter.formatSetpoint(clamped)
         if let id = targetTempId {
             bridge?.writeCharacteristic(identifier: id, value: Float(clamped))
             notifyLocalChange(characteristicId: id, value: Float(clamped))
@@ -428,20 +462,22 @@ class ThermostatMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRef
     }
 
     @objc private func decreaseTemp(_ sender: NSButton) {
-        setTargetTemp(TemperatureFormatter.step(targetTemp, by: -1))
+        setTargetTemp(TemperatureFormatter.step(targetTemp, by: -1, step: targetTempStep))
     }
 
     @objc private func increaseTemp(_ sender: NSButton) {
-        setTargetTemp(TemperatureFormatter.step(targetTemp, by: 1))
+        setTargetTemp(TemperatureFormatter.step(targetTemp, by: 1, step: targetTempStep))
     }
 
     // MARK: - Threshold controls (Auto mode)
 
     private func setHeatingThreshold(_ temp: Double) {
-        let maxHeat = coolingThreshold - 1
-        let clamped = min(max(temp, 10), maxHeat)
+        // The 1 °C gap below the cooling threshold stays even on half-degree
+        // devices; ecobee rejects writes with a smaller spread
+        let maxHeat = min(coolingThreshold - 1, heatingThresholdMax ?? .infinity)
+        let clamped = min(max(temp, heatingThresholdMin ?? 10), maxHeat)
         heatingThreshold = clamped
-        heatLabel.stringValue = TemperatureFormatter.format(clamped)
+        heatLabel.stringValue = TemperatureFormatter.formatSetpoint(clamped)
         if let id = heatingThresholdId {
             bridge?.writeCharacteristic(identifier: id, value: Float(clamped))
             notifyLocalChange(characteristicId: id, value: Float(clamped))
@@ -449,10 +485,10 @@ class ThermostatMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRef
     }
 
     private func setCoolingThreshold(_ temp: Double) {
-        let minCool = heatingThreshold + 1
-        let clamped = min(max(temp, minCool), 30)
+        let minCool = max(heatingThreshold + 1, coolingThresholdMin ?? -Double.infinity)
+        let clamped = min(max(temp, minCool), coolingThresholdMax ?? 30)
         coolingThreshold = clamped
-        coolLabel.stringValue = TemperatureFormatter.format(clamped)
+        coolLabel.stringValue = TemperatureFormatter.formatSetpoint(clamped)
         if let id = coolingThresholdId {
             bridge?.writeCharacteristic(identifier: id, value: Float(clamped))
             notifyLocalChange(characteristicId: id, value: Float(clamped))
@@ -460,18 +496,18 @@ class ThermostatMenuItem: NSMenuItem, CharacteristicUpdatable, CharacteristicRef
     }
 
     @objc private func decreaseHeatThreshold(_ sender: NSButton) {
-        setHeatingThreshold(TemperatureFormatter.step(heatingThreshold, by: -1))
+        setHeatingThreshold(TemperatureFormatter.step(heatingThreshold, by: -1, step: heatingThresholdStep))
     }
 
     @objc private func increaseHeatThreshold(_ sender: NSButton) {
-        setHeatingThreshold(TemperatureFormatter.step(heatingThreshold, by: 1))
+        setHeatingThreshold(TemperatureFormatter.step(heatingThreshold, by: 1, step: heatingThresholdStep))
     }
 
     @objc private func decreaseCoolThreshold(_ sender: NSButton) {
-        setCoolingThreshold(TemperatureFormatter.step(coolingThreshold, by: -1))
+        setCoolingThreshold(TemperatureFormatter.step(coolingThreshold, by: -1, step: coolingThresholdStep))
     }
 
     @objc private func increaseCoolThreshold(_ sender: NSButton) {
-        setCoolingThreshold(TemperatureFormatter.step(coolingThreshold, by: 1))
+        setCoolingThreshold(TemperatureFormatter.step(coolingThreshold, by: 1, step: coolingThresholdStep))
     }
 }

--- a/macOSBridge/Utilities/TemperatureFormatter.swift
+++ b/macOSBridge/Utilities/TemperatureFormatter.swift
@@ -47,6 +47,20 @@ enum TemperatureFormatter {
         return format(celsius, decimals: decimals)
     }
 
+    /// Format a setpoint value (in Celsius from HomeKit) for display,
+    /// keeping half degrees visible in Celsius mode: a 21.5 setpoint must
+    /// read "21.5°", not "22°". Fahrenheit mode delegates to format's
+    /// whole-degree ceil, unchanged.
+    static func formatSetpoint(_ celsius: Double) -> String {
+        guard !usesFahrenheit else { return format(celsius) }
+        let nearestWhole = celsius.rounded()
+        if abs(celsius - nearestWhole) < 0.05 {
+            // Within 0.05 of a whole number counts as whole (e.g. "21°")
+            return "\(Int(nearestWhole))°"
+        }
+        return String(format: "%.1f°", celsius)
+    }
+
     /// Convert Celsius to Fahrenheit
     static func celsiusToFahrenheit(_ celsius: Double) -> Double {
         celsius * 9.0 / 5.0 + 32.0
@@ -57,12 +71,32 @@ enum TemperatureFormatter {
         (fahrenheit - 32.0) * 5.0 / 9.0
     }
 
+    /// UI stepping increment derived from a characteristic's metadata step.
+    /// nil or non-positive metadata falls back to whole degrees; anything
+    /// else rounds UP to the nearest 0.5 °C with a floor of 0.5 °C, because
+    /// HomeKit's spec default step of 0.1 °C is unusable one click at a time.
+    static func uiStep(_ metadataStep: Double?) -> Double {
+        guard let metadataStep = metadataStep, metadataStep > 0 else { return 1.0 }
+        // The epsilon keeps 0.5 from becoming 1.0 through float noise
+        return max(0.5, ceil(metadataStep / 0.5 - 1e-9) * 0.5)
+    }
+
     /// One user-facing degree step from a Celsius value, in the current
     /// display unit. In Fahrenheit mode the step moves the displayed °F
     /// integer by exactly one degree – stepping the Celsius value directly
-    /// moves 1.8 °F and skips displayed degrees (72 → 70).
-    static func step(_ celsius: Double, by direction: Double) -> Double {
-        guard usesFahrenheit else { return celsius + direction }
+    /// moves 1.8 °F and skips displayed degrees (72 → 70) – and the Celsius
+    /// step grid is ignored. In Celsius mode the value snaps to the next
+    /// line of the step grid, so an off-grid 21.3 steps to 21.5 or 21.0.
+    static func step(_ celsius: Double, by direction: Double, step: Double = 1.0) -> Double {
+        guard usesFahrenheit else {
+            // Epsilons keep on-grid values (and float noise around them)
+            // from double-stepping or standing still.
+            let next = direction > 0
+                ? (floor(celsius / step + 1e-9) + 1) * step
+                : (ceil(celsius / step - 1e-9) - 1) * step
+            // Round the result onto the grid to kill float noise
+            return (next / step).rounded() * step
+        }
         // Mirror format(decimals: 0)'s ceil so the result lands exactly one
         // displayed degree away from what the label currently shows.
         let displayed = ceil(celsiusToFahrenheit(celsius))

--- a/macOSBridgeTests/ACMenuItemTests.swift
+++ b/macOSBridgeTests/ACMenuItemTests.swift
@@ -11,6 +11,18 @@ import AppKit
 
 final class ACMenuItemTests: XCTestCase {
 
+    private var savedUnit: String!
+
+    override func setUp() {
+        super.setUp()
+        savedUnit = PreferencesManager.shared.temperatureUnit
+    }
+
+    override func tearDown() {
+        PreferencesManager.shared.temperatureUnit = savedUnit
+        super.tearDown()
+    }
+
     // MARK: - Test helpers
 
     private func createTestServiceData(
@@ -20,7 +32,13 @@ final class ACMenuItemTests: XCTestCase {
         targetHeaterCoolerStateId: UUID? = nil,
         validTargetHeaterCoolerStates: [Int]? = nil,
         coolingThresholdTemperatureId: UUID? = nil,
+        coolingThresholdStep: Double? = nil,
+        coolingThresholdMin: Double? = nil,
+        coolingThresholdMax: Double? = nil,
         heatingThresholdTemperatureId: UUID? = nil,
+        heatingThresholdStep: Double? = nil,
+        heatingThresholdMin: Double? = nil,
+        heatingThresholdMax: Double? = nil,
         swingModeId: UUID? = nil
     ) -> ServiceData {
         ServiceData(
@@ -35,9 +53,53 @@ final class ACMenuItemTests: XCTestCase {
             targetHeaterCoolerStateId: targetHeaterCoolerStateId,
             validTargetHeaterCoolerStates: validTargetHeaterCoolerStates,
             coolingThresholdTemperatureId: coolingThresholdTemperatureId,
+            coolingThresholdStep: coolingThresholdStep,
+            coolingThresholdMin: coolingThresholdMin,
+            coolingThresholdMax: coolingThresholdMax,
             heatingThresholdTemperatureId: heatingThresholdTemperatureId,
+            heatingThresholdStep: heatingThresholdStep,
+            heatingThresholdMin: heatingThresholdMin,
+            heatingThresholdMax: heatingThresholdMax,
             swingModeId: swingModeId
         )
+    }
+
+    /// Recursively collects every NSTextField string value in a view tree
+    private func textFieldValues(in view: NSView) -> [String] {
+        var values: [String] = []
+        for subview in view.subviews {
+            if let field = subview as? NSTextField {
+                values.append(field.stringValue)
+            }
+            values.append(contentsOf: textFieldValues(in: subview))
+        }
+        return values
+    }
+
+    /// Recursively collects every NSTextField in a view tree
+    private func textFields(in view: NSView) -> [NSTextField] {
+        var fields: [NSTextField] = []
+        for subview in view.subviews {
+            if let field = subview as? NSTextField {
+                fields.append(field)
+            }
+            fields.append(contentsOf: textFields(in: subview))
+        }
+        return fields
+    }
+
+    /// Recursively collects StepperButton-created buttons by title and size,
+    /// left to right (the width disambiguates the regular single-target
+    /// steppers, 20 pt, from the mini range steppers, 11 pt)
+    private func stepperButtons(titled title: String, width: CGFloat, in view: NSView) -> [NSButton] {
+        var buttons: [NSButton] = []
+        for subview in view.subviews {
+            if let button = subview as? NSButton, button.title == title, button.frame.width == width {
+                buttons.append(button)
+            }
+            buttons.append(contentsOf: stepperButtons(titled: title, width: width, in: subview))
+        }
+        return buttons.sorted { $0.frame.origin.x < $1.frame.origin.x }
     }
 
     // MARK: - Initialisation tests
@@ -264,6 +326,156 @@ final class ACMenuItemTests: XCTestCase {
         // Should have exactly 2 ModeButton subviews
         let modeButtons = modeGroup!.subviews.compactMap { $0 as? ModeButton }
         XCTAssertEqual(modeButtons.count, 2)
+    }
+
+    // MARK: - Half-degree metadata tests
+
+    func testInitWithHalfDegreeMetadataCreatesView() {
+        let serviceData = createTestServiceData(
+            coolingThresholdTemperatureId: UUID(),
+            coolingThresholdStep: 0.5,
+            coolingThresholdMin: 16.0,
+            coolingThresholdMax: 30.0,
+            heatingThresholdTemperatureId: UUID(),
+            heatingThresholdStep: 0.5,
+            heatingThresholdMin: 16.0,
+            heatingThresholdMax: 30.0
+        )
+        let menuItem = ACMenuItem(serviceData: serviceData, bridge: nil)
+
+        XCTAssertNotNil(menuItem.view)
+    }
+
+    func testUpdateValueAcceptsHalfDegreeSetpoints() {
+        let coolingId = UUID()
+        let heatingId = UUID()
+        let serviceData = createTestServiceData(
+            coolingThresholdTemperatureId: coolingId,
+            coolingThresholdStep: 0.5,
+            heatingThresholdTemperatureId: heatingId,
+            heatingThresholdStep: 0.5
+        )
+        let menuItem = ACMenuItem(serviceData: serviceData, bridge: nil)
+
+        menuItem.updateValue(for: heatingId, value: 20.5)
+        menuItem.updateValue(for: coolingId, value: 24.5)
+
+        XCTAssertNotNil(menuItem.view)
+    }
+
+    func testUpdateCoolingThresholdDisplaysHalfDegreeInCelsius() {
+        PreferencesManager.shared.temperatureUnit = "celsius"
+
+        let coolingId = UUID()
+        let serviceData = createTestServiceData(
+            coolingThresholdTemperatureId: coolingId,
+            coolingThresholdStep: 0.5
+        )
+        let menuItem = ACMenuItem(serviceData: serviceData, bridge: nil)
+
+        menuItem.updateValue(for: coolingId, value: 22.5)
+
+        // The setpoint label must keep the half degree visible, not ceil to 23°
+        let labels = textFieldValues(in: menuItem.view!)
+        XCTAssertTrue(labels.contains("22.5°"), "Expected a setpoint label reading 22.5°, got \(labels)")
+    }
+
+    // MARK: - Fahrenheit stepping regression (AC unification)
+
+    func testFahrenheitSingleTargetClickMovesOneDisplayedDegree() {
+        PreferencesManager.shared.temperatureUnit = "fahrenheit"
+
+        // Cooling-only device: the single-target control drives the cooling
+        // threshold, so clicking its steppers exercises the real increase and
+        // decrease handlers, not just the formatter they delegate to
+        let coolingId = UUID()
+        let serviceData = createTestServiceData(coolingThresholdTemperatureId: coolingId)
+        let menuItem = ACMenuItem(serviceData: serviceData, bridge: nil)
+
+        menuItem.updateValue(for: coolingId, value: 22.0)
+        XCTAssertTrue(textFieldValues(in: menuItem.view!).contains("72°"))
+
+        let minusButtons = stepperButtons(titled: "−", width: 20, in: menuItem.view!)
+        let plusButtons = stepperButtons(titled: "+", width: 20, in: menuItem.view!)
+        XCTAssertEqual(minusButtons.count, 1)
+        XCTAssertEqual(plusButtons.count, 1)
+
+        // One click moves exactly one displayed °F; the pre-unification raw
+        // −1 °C stepping jumped 1.8 °F and skipped 71° entirely
+        minusButtons[0].performClick(nil)
+        XCTAssertTrue(textFieldValues(in: menuItem.view!).contains("71°"),
+                      "A stepper click must move one displayed °F")
+
+        plusButtons[0].performClick(nil)
+        XCTAssertTrue(textFieldValues(in: menuItem.view!).contains("72°"))
+    }
+
+    func testCelsiusSingleTargetClickHonoursHalfDegreeStep() {
+        PreferencesManager.shared.temperatureUnit = "celsius"
+
+        let coolingId = UUID()
+        let serviceData = createTestServiceData(
+            coolingThresholdTemperatureId: coolingId,
+            coolingThresholdStep: 0.5
+        )
+        let menuItem = ACMenuItem(serviceData: serviceData, bridge: nil)
+
+        menuItem.updateValue(for: coolingId, value: 22.0)
+
+        let plusButtons = stepperButtons(titled: "+", width: 20, in: menuItem.view!)
+        XCTAssertEqual(plusButtons.count, 1)
+
+        plusButtons[0].performClick(nil)
+        XCTAssertTrue(textFieldValues(in: menuItem.view!).contains("22.5°"),
+                      "A 0.5 °C device must step the setpoint by half a degree")
+    }
+
+    func testConstructionPlaceholdersStayLiteralInFahrenheit() {
+        PreferencesManager.shared.temperatureUnit = "fahrenheit"
+
+        let serviceData = createTestServiceData(
+            coolingThresholdTemperatureId: UUID(),
+            heatingThresholdTemperatureId: UUID()
+        )
+        let menuItem = ACMenuItem(serviceData: serviceData, bridge: nil)
+
+        // Until a real characteristic value arrives the labels keep the
+        // pre-metadata literals; converting them at construction would change
+        // Fahrenheit behaviour, which the half-degree feature must not touch
+        let labels = textFieldValues(in: menuItem.view!)
+        XCTAssertTrue(labels.contains("24°"), "Expected the literal 24° placeholder, got \(labels)")
+        XCTAssertTrue(labels.contains("20°"), "Expected the literal 20° placeholder, got \(labels)")
+        XCTAssertFalse(labels.contains("76°"))
+        XCTAssertFalse(labels.contains("68°"))
+    }
+
+    // MARK: - Range control layout tests
+
+    func testRangeLabelsFitWidestHalfDegreeStringAndClearModeButtons() {
+        let serviceData = createTestServiceData(
+            coolingThresholdTemperatureId: UUID(),
+            heatingThresholdTemperatureId: UUID()
+        )
+        let menuItem = ACMenuItem(serviceData: serviceData, bridge: nil)
+
+        // The mini range labels (the height-14 fields) must hold "34.5°", the
+        // widest realistic half-degree string; NSTextField eats about 3 pt of
+        // a centred label's width in cell insets before glyphs clip
+        let rangeLabels = textFields(in: menuItem.view!).filter { $0.frame.height == 14 }
+        XCTAssertEqual(rangeLabels.count, 2)
+        let required = ("34.5°" as NSString)
+            .size(withAttributes: [.font: DS.Typography.labelSmall]).width
+        for label in rangeLabels {
+            XCTAssertGreaterThanOrEqual(label.frame.width - 3, required,
+                                        "A \(label.frame.width) pt range label clips 34.5°")
+        }
+
+        // The widened control must still clear the 3-button mode group
+        let modeGroup = findSubview(of: ModeButtonGroup.self, in: menuItem.view!)
+        XCTAssertNotNil(modeGroup)
+        let rangeContainer = rangeLabels[0].superview!
+        XCTAssertGreaterThanOrEqual(rangeContainer.frame.minX, modeGroup!.frame.maxX + 2,
+                                    "Range control overlaps the mode button group")
     }
 
     // MARK: - Protocol conformance tests

--- a/macOSBridgeTests/HAClimateMenuItemTests.swift
+++ b/macOSBridgeTests/HAClimateMenuItemTests.swift
@@ -1,0 +1,235 @@
+//
+//  HAClimateMenuItemTests.swift
+//  macOSBridgeTests
+//
+//  Tests for HAClimateMenuItem
+//
+
+import XCTest
+import AppKit
+@testable import macOSBridge
+
+final class HAClimateMenuItemTests: XCTestCase {
+
+    private var savedUnit: String!
+
+    override func setUp() {
+        super.setUp()
+        savedUnit = PreferencesManager.shared.temperatureUnit
+    }
+
+    override func tearDown() {
+        PreferencesManager.shared.temperatureUnit = savedUnit
+        super.tearDown()
+    }
+
+    // MARK: - Test helpers
+
+    private func createTestServiceData(
+        currentTemperatureId: UUID? = UUID(),
+        targetTemperatureId: UUID? = UUID(),
+        targetTemperatureStep: Double? = nil,
+        targetTemperatureMin: Double? = nil,
+        targetTemperatureMax: Double? = nil,
+        heatingCoolingStateId: UUID? = nil,
+        targetHeatingCoolingStateId: UUID? = nil,
+        availableHVACModes: [String]? = ["off", "heat", "cool"],
+        coolingThresholdTemperatureId: UUID? = nil,
+        coolingThresholdStep: Double? = nil,
+        coolingThresholdMin: Double? = nil,
+        coolingThresholdMax: Double? = nil,
+        heatingThresholdTemperatureId: UUID? = nil,
+        heatingThresholdStep: Double? = nil,
+        heatingThresholdMin: Double? = nil,
+        heatingThresholdMax: Double? = nil
+    ) -> ServiceData {
+        ServiceData(
+            uniqueIdentifier: UUID(),
+            name: "Test Climate",
+            serviceType: ServiceTypes.thermostat,
+            accessoryName: "Test Accessory",
+            roomIdentifier: nil,
+            currentTemperatureId: currentTemperatureId,
+            targetTemperatureId: targetTemperatureId,
+            targetTemperatureStep: targetTemperatureStep,
+            targetTemperatureMin: targetTemperatureMin,
+            targetTemperatureMax: targetTemperatureMax,
+            heatingCoolingStateId: heatingCoolingStateId,
+            targetHeatingCoolingStateId: targetHeatingCoolingStateId,
+            availableHVACModes: availableHVACModes,
+            coolingThresholdTemperatureId: coolingThresholdTemperatureId,
+            coolingThresholdStep: coolingThresholdStep,
+            coolingThresholdMin: coolingThresholdMin,
+            coolingThresholdMax: coolingThresholdMax,
+            heatingThresholdTemperatureId: heatingThresholdTemperatureId,
+            heatingThresholdStep: heatingThresholdStep,
+            heatingThresholdMin: heatingThresholdMin,
+            heatingThresholdMax: heatingThresholdMax
+        )
+    }
+
+    /// Recursively collects every NSTextField string value in a view tree
+    private func textFieldValues(in view: NSView) -> [String] {
+        var values: [String] = []
+        for subview in view.subviews {
+            if let field = subview as? NSTextField {
+                values.append(field.stringValue)
+            }
+            values.append(contentsOf: textFieldValues(in: subview))
+        }
+        return values
+    }
+
+    /// Recursively collects StepperButton-created buttons by title and size,
+    /// left to right (the width disambiguates the regular single-target
+    /// steppers, 20 pt, from the small range steppers, 16 pt)
+    private func stepperButtons(titled title: String, width: CGFloat, in view: NSView) -> [NSButton] {
+        var buttons: [NSButton] = []
+        for subview in view.subviews {
+            if let button = subview as? NSButton, button.title == title, button.frame.width == width {
+                buttons.append(button)
+            }
+            buttons.append(contentsOf: stepperButtons(titled: title, width: width, in: subview))
+        }
+        return buttons.sorted { $0.frame.origin.x < $1.frame.origin.x }
+    }
+
+    // MARK: - Initialisation tests
+
+    func testInitSetsServiceData() {
+        let serviceData = createTestServiceData()
+        let menuItem = HAClimateMenuItem(serviceData: serviceData, bridge: nil)
+
+        XCTAssertEqual(menuItem.serviceData.name, "Test Climate")
+        XCTAssertEqual(menuItem.serviceData.serviceType, ServiceTypes.thermostat)
+    }
+
+    func testInitCreatesView() {
+        let serviceData = createTestServiceData()
+        let menuItem = HAClimateMenuItem(serviceData: serviceData, bridge: nil)
+
+        XCTAssertNotNil(menuItem.view)
+    }
+
+    func testInitCreatesViewWithStepMetadata() {
+        let serviceData = createTestServiceData(
+            targetTemperatureStep: 0.5,
+            targetTemperatureMin: 7,
+            targetTemperatureMax: 35
+        )
+        let menuItem = HAClimateMenuItem(serviceData: serviceData, bridge: nil)
+
+        XCTAssertNotNil(menuItem.view)
+    }
+
+    func testInitCreatesViewWithThresholdStepMetadata() {
+        let serviceData = createTestServiceData(
+            coolingThresholdTemperatureId: UUID(),
+            coolingThresholdStep: 0.5,
+            heatingThresholdTemperatureId: UUID(),
+            heatingThresholdStep: 0.5
+        )
+        let menuItem = HAClimateMenuItem(serviceData: serviceData, bridge: nil)
+
+        XCTAssertNotNil(menuItem.view)
+    }
+
+    // MARK: - Value update tests
+
+    func testUpdateTargetTemperatureHalfDegreeShowsHalf() {
+        PreferencesManager.shared.temperatureUnit = "celsius"
+
+        let tempId = UUID()
+        let serviceData = createTestServiceData(targetTemperatureId: tempId)
+        let menuItem = HAClimateMenuItem(serviceData: serviceData, bridge: nil)
+
+        menuItem.updateValue(for: tempId, value: 21.5)
+
+        XCTAssertNotNil(menuItem.view)
+        // A 21.5 setpoint must read 21.5°, not 22°
+        XCTAssertTrue(textFieldValues(in: menuItem.view!).contains("21.5°"))
+    }
+
+    func testUpdateTargetTemperatureHalfDegreeWithStepMetadata() {
+        PreferencesManager.shared.temperatureUnit = "celsius"
+
+        let tempId = UUID()
+        let serviceData = createTestServiceData(
+            targetTemperatureId: tempId,
+            targetTemperatureStep: 0.5,
+            targetTemperatureMin: 7,
+            targetTemperatureMax: 35
+        )
+        let menuItem = HAClimateMenuItem(serviceData: serviceData, bridge: nil)
+
+        menuItem.updateValue(for: tempId, value: 21.5)
+
+        XCTAssertNotNil(menuItem.view)
+        XCTAssertTrue(textFieldValues(in: menuItem.view!).contains("21.5°"))
+    }
+
+    func testConstructionPlaceholdersStayLiteralInFahrenheit() {
+        PreferencesManager.shared.temperatureUnit = "fahrenheit"
+
+        let serviceData = createTestServiceData(
+            coolingThresholdTemperatureId: UUID(),
+            heatingThresholdTemperatureId: UUID()
+        )
+        let menuItem = HAClimateMenuItem(serviceData: serviceData, bridge: nil)
+
+        // Until a real characteristic value arrives the labels keep the
+        // pre-metadata literals; converting them at construction would change
+        // Fahrenheit behaviour, which the half-degree feature must not touch
+        let labels = textFieldValues(in: menuItem.view!)
+        XCTAssertTrue(labels.contains("20°"), "Expected the literal 20° placeholder, got \(labels)")
+        XCTAssertTrue(labels.contains("18°"), "Expected the literal 18° placeholder, got \(labels)")
+        XCTAssertTrue(labels.contains("24°"), "Expected the literal 24° placeholder, got \(labels)")
+        XCTAssertFalse(labels.contains("68°"))
+        XCTAssertFalse(labels.contains("65°"))
+        XCTAssertFalse(labels.contains("76°"))
+    }
+
+    // MARK: - Threshold clamp metadata tests
+
+    func testHeatThresholdClicksClampToMetadataMax() {
+        PreferencesManager.shared.temperatureUnit = "celsius"
+
+        let serviceData = createTestServiceData(
+            coolingThresholdTemperatureId: UUID(),
+            heatingThresholdTemperatureId: UUID(),
+            heatingThresholdMax: 20.5
+        )
+        let menuItem = HAClimateMenuItem(serviceData: serviceData, bridge: nil)
+
+        // Heating starts at the 18 default; three whole-degree clicks walk
+        // 19, 20, then clamp at the 20.5 metadata max instead of reaching 21
+        let heatPlus = stepperButtons(titled: "+", width: 16, in: menuItem.view!).first
+        XCTAssertNotNil(heatPlus)
+        for _ in 0..<3 { heatPlus!.performClick(nil) }
+
+        let labels = textFieldValues(in: menuItem.view!)
+        XCTAssertTrue(labels.contains("20.5°"), "Expected the heat threshold clamped to 20.5°, got \(labels)")
+        XCTAssertFalse(labels.contains("21°"))
+    }
+
+    func testCoolThresholdClicksClampToMetadataMin() {
+        PreferencesManager.shared.temperatureUnit = "celsius"
+
+        let serviceData = createTestServiceData(
+            coolingThresholdTemperatureId: UUID(),
+            coolingThresholdMin: 22.5,
+            heatingThresholdTemperatureId: UUID()
+        )
+        let menuItem = HAClimateMenuItem(serviceData: serviceData, bridge: nil)
+
+        // Cooling starts at the 24 default; three clicks down walk 23, then
+        // clamp at the 22.5 metadata min instead of reaching 21
+        let coolMinus = stepperButtons(titled: "−", width: 16, in: menuItem.view!).last
+        XCTAssertNotNil(coolMinus)
+        for _ in 0..<3 { coolMinus!.performClick(nil) }
+
+        let labels = textFieldValues(in: menuItem.view!)
+        XCTAssertTrue(labels.contains("22.5°"), "Expected the cool threshold clamped to 22.5°, got \(labels)")
+        XCTAssertFalse(labels.contains("21°"))
+    }
+}

--- a/macOSBridgeTests/HomeAssistant/EntityMapperTests.swift
+++ b/macOSBridgeTests/HomeAssistant/EntityMapperTests.swift
@@ -362,6 +362,96 @@ final class EntityMapperTests: XCTestCase {
         }
     }
 
+    func testClimateStepAndRangeMetadataMapsToServiceData() {
+        let state = createEntityState(
+            entityId: "climate.eve_thermo",
+            state: "heat",
+            attributes: [
+                "friendly_name": "Eve Thermo",
+                "current_temperature": 21.0,
+                "temperature": 21.5,
+                "target_temp_step": 0.5,
+                "min_temp": 7.0,
+                "max_temp": 35.0,
+                "hvac_modes": ["off", "heat"]
+            ]
+        )
+        loadData(states: [state])
+
+        let menuData = mapper.generateMenuData()
+
+        // HA has one step/min/max set per entity, so the same values feed
+        // the target trio and both threshold trios
+        let service = menuData.accessories.first?.services.first
+        XCTAssertEqual(service?.targetTemperatureStep, 0.5)
+        XCTAssertEqual(service?.targetTemperatureMin, 7.0)
+        XCTAssertEqual(service?.targetTemperatureMax, 35.0)
+        XCTAssertEqual(service?.heatingThresholdStep, 0.5)
+        XCTAssertEqual(service?.heatingThresholdMin, 7.0)
+        XCTAssertEqual(service?.heatingThresholdMax, 35.0)
+        XCTAssertEqual(service?.coolingThresholdStep, 0.5)
+        XCTAssertEqual(service?.coolingThresholdMin, 7.0)
+        XCTAssertEqual(service?.coolingThresholdMax, 35.0)
+    }
+
+    func testClimateWithoutStepMetadataLeavesFieldsNil() {
+        let state = createEntityState(
+            entityId: "climate.basic",
+            state: "heat",
+            attributes: [
+                "friendly_name": "Basic Thermostat",
+                "temperature": 21.0,
+                "hvac_modes": ["off", "heat"]
+            ]
+        )
+        loadData(states: [state])
+
+        let menuData = mapper.generateMenuData()
+
+        let service = menuData.accessories.first?.services.first
+        XCTAssertNil(service?.targetTemperatureStep)
+        XCTAssertNil(service?.targetTemperatureMin)
+        XCTAssertNil(service?.targetTemperatureMax)
+        XCTAssertNil(service?.heatingThresholdStep)
+        XCTAssertNil(service?.heatingThresholdMin)
+        XCTAssertNil(service?.heatingThresholdMax)
+        XCTAssertNil(service?.coolingThresholdStep)
+        XCTAssertNil(service?.coolingThresholdMin)
+        XCTAssertNil(service?.coolingThresholdMax)
+    }
+
+    func testClimateFahrenheitServerScalesStepAndNormalizesRange() {
+        mapper.setTemperatureUnit("°F")
+        let state = createEntityState(
+            entityId: "climate.us_thermostat",
+            state: "heat",
+            attributes: [
+                "friendly_name": "US Thermostat",
+                "temperature": 70.0,
+                "target_temp_step": 1.0,
+                "min_temp": 45.0,
+                "max_temp": 95.0,
+                "hvac_modes": ["off", "heat"]
+            ]
+        )
+        loadData(states: [state])
+
+        let menuData = mapper.generateMenuData()
+
+        let service = menuData.accessories.first?.services.first
+        // The step is a delta, so it scales by 5/9 with no -32 offset
+        XCTAssertEqual(service?.targetTemperatureStep ?? -1, 5.0 / 9.0, accuracy: 0.0001)
+        XCTAssertEqual(service?.heatingThresholdStep ?? -1, 5.0 / 9.0, accuracy: 0.0001)
+        XCTAssertEqual(service?.coolingThresholdStep ?? -1, 5.0 / 9.0, accuracy: 0.0001)
+        // Absolute bounds normalize with the offset: 45°F is 7.22°C, 95°F is 35°C
+        XCTAssertEqual(service?.targetTemperatureMin ?? -1, (45.0 - 32.0) * 5.0 / 9.0, accuracy: 0.0001)
+        XCTAssertEqual(service?.targetTemperatureMax ?? -1, 35.0, accuracy: 0.0001)
+        XCTAssertEqual(service?.heatingThresholdMin ?? -1, (45.0 - 32.0) * 5.0 / 9.0, accuracy: 0.0001)
+        XCTAssertEqual(service?.heatingThresholdMax ?? -1, 35.0, accuracy: 0.0001)
+        XCTAssertEqual(service?.coolingThresholdMin ?? -1, (45.0 - 32.0) * 5.0 / 9.0, accuracy: 0.0001)
+        XCTAssertEqual(service?.coolingThresholdMax ?? -1, 35.0, accuracy: 0.0001)
+    }
+
     // MARK: - Lock mapping tests
 
     func testLockMapsToLockMechanism() {

--- a/macOSBridgeTests/ServiceDataTests.swift
+++ b/macOSBridgeTests/ServiceDataTests.swift
@@ -101,4 +101,70 @@ final class ServiceDataTests: XCTestCase {
         XCTAssertNil(service.carbonMonoxideDetectedId)
         XCTAssertNil(service.carbonDioxideDetectedId)
     }
+
+    // MARK: - Temperature setpoint metadata (Codable round-trip)
+
+    // Setpoint step/min/max metadata crosses the iOS <-> macOSBridge process
+    // boundary as JSON next to the characteristic ids, so all nine fields must
+    // survive encode + decode with their values intact.
+    func testSetpointMetadataRoundTripsThroughCodable() throws {
+        let original = ServiceData(
+            uniqueIdentifier: UUID(),
+            name: "Thermostat",
+            serviceType: ServiceTypes.thermostat,
+            accessoryName: "Thermostat",
+            roomIdentifier: nil,
+            targetTemperatureId: UUID(),
+            targetTemperatureStep: 0.5,
+            targetTemperatureMin: 10.0,
+            targetTemperatureMax: 30.0,
+            coolingThresholdTemperatureId: UUID(),
+            coolingThresholdStep: 1.0,
+            coolingThresholdMin: 18.3,
+            coolingThresholdMax: 33.3,
+            heatingThresholdTemperatureId: UUID(),
+            heatingThresholdStep: 0.1,
+            heatingThresholdMin: 7.2,
+            heatingThresholdMax: 26.1
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ServiceData.self, from: encoded)
+
+        XCTAssertEqual(decoded.targetTemperatureStep, 0.5)
+        XCTAssertEqual(decoded.targetTemperatureMin, 10.0)
+        XCTAssertEqual(decoded.targetTemperatureMax, 30.0)
+        XCTAssertEqual(decoded.coolingThresholdStep, 1.0)
+        XCTAssertEqual(decoded.coolingThresholdMin, 18.3)
+        XCTAssertEqual(decoded.coolingThresholdMax, 33.3)
+        XCTAssertEqual(decoded.heatingThresholdStep, 0.1)
+        XCTAssertEqual(decoded.heatingThresholdMin, 7.2)
+        XCTAssertEqual(decoded.heatingThresholdMax, 26.1)
+    }
+
+    // Older builds encoded ServiceData without the setpoint metadata fields, so
+    // decoding a legacy payload must yield nil for each rather than throwing.
+    func testSetpointMetadataDecodesAsNilFromLegacyJSON() throws {
+        let legacyJSON = """
+        {
+            "uniqueIdentifier": "\(UUID().uuidString)",
+            "name": "Legacy Thermostat",
+            "serviceType": "\(ServiceTypes.thermostat)",
+            "accessoryName": "Legacy Thermostat",
+            "isReachable": true
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(ServiceData.self, from: Data(legacyJSON.utf8))
+
+        XCTAssertNil(decoded.targetTemperatureStep)
+        XCTAssertNil(decoded.targetTemperatureMin)
+        XCTAssertNil(decoded.targetTemperatureMax)
+        XCTAssertNil(decoded.heatingThresholdStep)
+        XCTAssertNil(decoded.heatingThresholdMin)
+        XCTAssertNil(decoded.heatingThresholdMax)
+        XCTAssertNil(decoded.coolingThresholdStep)
+        XCTAssertNil(decoded.coolingThresholdMin)
+        XCTAssertNil(decoded.coolingThresholdMax)
+    }
 }

--- a/macOSBridgeTests/TemperatureFormatterTests.swift
+++ b/macOSBridgeTests/TemperatureFormatterTests.swift
@@ -81,4 +81,96 @@ final class TemperatureFormatterTests: XCTestCase {
         let roundTripped = TemperatureFormatter.fahrenheitToCelsius(TemperatureFormatter.celsiusToFahrenheit(celsius))
         XCTAssertEqual(roundTripped, celsius, accuracy: 0.0001)
     }
+
+    // MARK: - UI step derivation from characteristic metadata
+
+    func testUIStepDefaultsToWholeDegreeWithoutMetadata() {
+        XCTAssertEqual(TemperatureFormatter.uiStep(nil), 1.0)
+        XCTAssertEqual(TemperatureFormatter.uiStep(0), 1.0)
+        XCTAssertEqual(TemperatureFormatter.uiStep(-1), 1.0)
+    }
+
+    func testUIStepRoundsUpToNearestHalfDegree() {
+        // HomeKit's spec default step is 0.1°C; clicking in 0.1° increments
+        // is unusable, so anything below 0.5 floors to 0.5
+        XCTAssertEqual(TemperatureFormatter.uiStep(0.1), 0.5)
+        XCTAssertEqual(TemperatureFormatter.uiStep(0.5), 0.5)
+        XCTAssertEqual(TemperatureFormatter.uiStep(0.6), 1.0)
+        XCTAssertEqual(TemperatureFormatter.uiStep(1.0), 1.0)
+        XCTAssertEqual(TemperatureFormatter.uiStep(2.0), 2.0)
+    }
+
+    // MARK: - Stepping in Celsius on a half-degree grid
+
+    func testCelsiusHalfDegreeStepFromOnGridValue() {
+        PreferencesManager.shared.temperatureUnit = "celsius"
+
+        XCTAssertEqual(TemperatureFormatter.step(21.0, by: 1, step: 0.5), 21.5)
+        XCTAssertEqual(TemperatureFormatter.step(21.0, by: -1, step: 0.5), 20.5)
+    }
+
+    func testCelsiusHalfDegreeStepSnapsOffGridValueToGrid() {
+        PreferencesManager.shared.temperatureUnit = "celsius"
+
+        // An off-grid 21.3°C lands on the next grid line, not 21.8/20.8
+        XCTAssertEqual(TemperatureFormatter.step(21.3, by: 1, step: 0.5), 21.5)
+        XCTAssertEqual(TemperatureFormatter.step(21.3, by: -1, step: 0.5), 21.0)
+    }
+
+    func testCelsiusHalfDegreeStepAbsorbsFloatNoise() {
+        PreferencesManager.shared.temperatureUnit = "celsius"
+
+        // Float noise just under 21.0°C must step as if it were on grid
+        XCTAssertEqual(TemperatureFormatter.step(20.9999999999, by: 1, step: 0.5), 21.5)
+    }
+
+    func testCelsiusDefaultStepStaysOneDegree() {
+        PreferencesManager.shared.temperatureUnit = "celsius"
+
+        // Explicit step 1.0 matches testCelsiusStepIsOneDegree's semantics
+        XCTAssertEqual(TemperatureFormatter.step(22.0, by: -1, step: 1.0), 21.0)
+        XCTAssertEqual(TemperatureFormatter.step(22.0, by: 1, step: 1.0), 23.0)
+    }
+
+    // MARK: - Stepping in Fahrenheit ignores the Celsius step grid
+
+    func testFahrenheitStepWithHalfDegreeGridStillMovesOneDisplayedDegree() {
+        PreferencesManager.shared.temperatureUnit = "fahrenheit"
+
+        // Mirrors testFahrenheitStepDownHitsEveryDegree with a 0.5°C device
+        // grid present; Fahrenheit stepping stays one displayed degree
+        var celsius = 22.0
+        XCTAssertEqual(TemperatureFormatter.format(celsius), "72°")
+
+        celsius = TemperatureFormatter.step(celsius, by: -1, step: 0.5)
+        XCTAssertEqual(TemperatureFormatter.format(celsius), "71°")
+
+        celsius = TemperatureFormatter.step(celsius, by: -1, step: 0.5)
+        XCTAssertEqual(TemperatureFormatter.format(celsius), "70°")
+    }
+
+    // MARK: - Setpoint display keeps half degrees visible in Celsius
+
+    func testFormatSetpointCelsiusWholeAndHalfDegrees() {
+        PreferencesManager.shared.temperatureUnit = "celsius"
+
+        XCTAssertEqual(TemperatureFormatter.formatSetpoint(21.0), "21°")
+        XCTAssertEqual(TemperatureFormatter.formatSetpoint(21.5), "21.5°")
+        // Values within 0.05 of a whole number render without decimals
+        XCTAssertEqual(TemperatureFormatter.formatSetpoint(20.999999999), "21°")
+    }
+
+    func testFormatSetpointCelsiusNegativeHalfDegree() {
+        PreferencesManager.shared.temperatureUnit = "celsius"
+
+        XCTAssertEqual(TemperatureFormatter.formatSetpoint(-0.5), "-0.5°")
+    }
+
+    func testFormatSetpointFahrenheitDelegatesToWholeDegreeCeil() {
+        PreferencesManager.shared.temperatureUnit = "fahrenheit"
+
+        // 21.5°C is 70.7°F; Fahrenheit setpoints keep format's ceil
+        XCTAssertEqual(TemperatureFormatter.formatSetpoint(21.5), TemperatureFormatter.format(21.5))
+        XCTAssertEqual(TemperatureFormatter.formatSetpoint(21.5), "71°")
+    }
 }

--- a/macOSBridgeTests/ThermostatMenuItemTests.swift
+++ b/macOSBridgeTests/ThermostatMenuItemTests.swift
@@ -11,15 +11,36 @@ import AppKit
 
 final class ThermostatMenuItemTests: XCTestCase {
 
+    private var savedUnit: String!
+
+    override func setUp() {
+        super.setUp()
+        savedUnit = PreferencesManager.shared.temperatureUnit
+    }
+
+    override func tearDown() {
+        PreferencesManager.shared.temperatureUnit = savedUnit
+        super.tearDown()
+    }
+
     // MARK: - Test helpers
 
     private func createTestServiceData(
         currentTemperatureId: UUID? = UUID(),
         targetTemperatureId: UUID? = UUID(),
+        targetTemperatureStep: Double? = nil,
+        targetTemperatureMin: Double? = nil,
+        targetTemperatureMax: Double? = nil,
         heatingCoolingStateId: UUID? = nil,
         targetHeatingCoolingStateId: UUID? = nil,
         coolingThresholdTemperatureId: UUID? = nil,
-        heatingThresholdTemperatureId: UUID? = nil
+        coolingThresholdStep: Double? = nil,
+        coolingThresholdMin: Double? = nil,
+        coolingThresholdMax: Double? = nil,
+        heatingThresholdTemperatureId: UUID? = nil,
+        heatingThresholdStep: Double? = nil,
+        heatingThresholdMin: Double? = nil,
+        heatingThresholdMax: Double? = nil
     ) -> ServiceData {
         ServiceData(
             uniqueIdentifier: UUID(),
@@ -29,11 +50,53 @@ final class ThermostatMenuItemTests: XCTestCase {
             roomIdentifier: nil,
             currentTemperatureId: currentTemperatureId,
             targetTemperatureId: targetTemperatureId,
+            targetTemperatureStep: targetTemperatureStep,
+            targetTemperatureMin: targetTemperatureMin,
+            targetTemperatureMax: targetTemperatureMax,
             heatingCoolingStateId: heatingCoolingStateId,
             targetHeatingCoolingStateId: targetHeatingCoolingStateId,
             coolingThresholdTemperatureId: coolingThresholdTemperatureId,
-            heatingThresholdTemperatureId: heatingThresholdTemperatureId
+            coolingThresholdStep: coolingThresholdStep,
+            coolingThresholdMin: coolingThresholdMin,
+            coolingThresholdMax: coolingThresholdMax,
+            heatingThresholdTemperatureId: heatingThresholdTemperatureId,
+            heatingThresholdStep: heatingThresholdStep,
+            heatingThresholdMin: heatingThresholdMin,
+            heatingThresholdMax: heatingThresholdMax
         )
+    }
+
+    /// Recursively collects every NSTextField string value in a view tree
+    private func textFieldValues(in view: NSView) -> [String] {
+        var values: [String] = []
+        for subview in view.subviews {
+            if let field = subview as? NSTextField {
+                values.append(field.stringValue)
+            }
+            values.append(contentsOf: textFieldValues(in: subview))
+        }
+        return values
+    }
+
+    /// Recursively collects every NSTextField in a view tree
+    private func textFields(in view: NSView) -> [NSTextField] {
+        var fields: [NSTextField] = []
+        for subview in view.subviews {
+            if let field = subview as? NSTextField {
+                fields.append(field)
+            }
+            fields.append(contentsOf: textFields(in: subview))
+        }
+        return fields
+    }
+
+    /// Recursively finds the first subview of a given type
+    private func findSubview<T: NSView>(of type: T.Type, in view: NSView) -> T? {
+        for subview in view.subviews {
+            if let match = subview as? T { return match }
+            if let found = findSubview(of: type, in: subview) { return found }
+        }
+        return nil
     }
 
     // MARK: - Initialisation tests
@@ -202,6 +265,115 @@ final class ThermostatMenuItemTests: XCTestCase {
         menuItem.updateValue(for: unknownId, value: 50)
 
         XCTAssertNotNil(menuItem.view)
+    }
+
+    // MARK: - Half-degree metadata tests
+
+    func testInitWithHalfDegreeMetadataCreatesView() {
+        let serviceData = createTestServiceData(
+            targetTemperatureStep: 0.5,
+            targetTemperatureMin: 7.0,
+            targetTemperatureMax: 35.0,
+            coolingThresholdTemperatureId: UUID(),
+            coolingThresholdStep: 0.5,
+            coolingThresholdMin: 18.3,
+            coolingThresholdMax: 33.3,
+            heatingThresholdTemperatureId: UUID(),
+            heatingThresholdStep: 0.5,
+            heatingThresholdMin: 7.2,
+            heatingThresholdMax: 26.1
+        )
+        let menuItem = ThermostatMenuItem(serviceData: serviceData, bridge: nil)
+
+        XCTAssertNotNil(menuItem.view)
+    }
+
+    func testUpdateValueAcceptsHalfDegreeSetpoints() {
+        let targetId = UUID()
+        let coolingId = UUID()
+        let heatingId = UUID()
+        let serviceData = createTestServiceData(
+            targetTemperatureId: targetId,
+            targetTemperatureStep: 0.5,
+            coolingThresholdTemperatureId: coolingId,
+            coolingThresholdStep: 0.5,
+            heatingThresholdTemperatureId: heatingId,
+            heatingThresholdStep: 0.5
+        )
+        let menuItem = ThermostatMenuItem(serviceData: serviceData, bridge: nil)
+
+        menuItem.updateValue(for: targetId, value: 21.5)
+        menuItem.updateValue(for: heatingId, value: 18.5)
+        menuItem.updateValue(for: coolingId, value: 24.5)
+
+        XCTAssertNotNil(menuItem.view)
+    }
+
+    func testUpdateTargetTemperatureDisplaysHalfDegreeInCelsius() {
+        PreferencesManager.shared.temperatureUnit = "celsius"
+
+        let targetId = UUID()
+        let serviceData = createTestServiceData(
+            targetTemperatureId: targetId,
+            targetTemperatureStep: 0.5
+        )
+        let menuItem = ThermostatMenuItem(serviceData: serviceData, bridge: nil)
+
+        menuItem.updateValue(for: targetId, value: 21.5)
+
+        // The setpoint label must keep the half degree visible, not ceil to 22°
+        let labels = textFieldValues(in: menuItem.view!)
+        XCTAssertTrue(labels.contains("21.5°"), "Expected a setpoint label reading 21.5°, got \(labels)")
+    }
+
+    func testConstructionPlaceholdersStayLiteralInFahrenheit() {
+        PreferencesManager.shared.temperatureUnit = "fahrenheit"
+
+        let serviceData = createTestServiceData(
+            coolingThresholdTemperatureId: UUID(),
+            heatingThresholdTemperatureId: UUID()
+        )
+        let menuItem = ThermostatMenuItem(serviceData: serviceData, bridge: nil)
+
+        // Until a real characteristic value arrives the labels keep the
+        // pre-metadata literals; converting them at construction would change
+        // Fahrenheit behaviour, which the half-degree feature must not touch
+        let labels = textFieldValues(in: menuItem.view!)
+        XCTAssertTrue(labels.contains("20°"), "Expected the literal 20° placeholder, got \(labels)")
+        XCTAssertTrue(labels.contains("18°"), "Expected the literal 18° placeholder, got \(labels)")
+        XCTAssertTrue(labels.contains("24°"), "Expected the literal 24° placeholder, got \(labels)")
+        XCTAssertFalse(labels.contains("68°"))
+        XCTAssertFalse(labels.contains("65°"))
+        XCTAssertFalse(labels.contains("76°"))
+    }
+
+    // MARK: - Range control layout tests
+
+    func testRangeLabelsFitWidestHalfDegreeStringAndClearModeButtons() {
+        let serviceData = createTestServiceData(
+            coolingThresholdTemperatureId: UUID(),
+            heatingThresholdTemperatureId: UUID()
+        )
+        let menuItem = ThermostatMenuItem(serviceData: serviceData, bridge: nil)
+
+        // The mini range labels (the height-14 fields) must hold "34.5°", the
+        // widest realistic half-degree string; NSTextField eats about 3 pt of
+        // a centred label's width in cell insets before glyphs clip
+        let rangeLabels = textFields(in: menuItem.view!).filter { $0.frame.height == 14 }
+        XCTAssertEqual(rangeLabels.count, 2)
+        let required = ("34.5°" as NSString)
+            .size(withAttributes: [.font: DS.Typography.labelSmall]).width
+        for label in rangeLabels {
+            XCTAssertGreaterThanOrEqual(label.frame.width - 3, required,
+                                        "A \(label.frame.width) pt range label clips 34.5°")
+        }
+
+        // The widened control must still clear the 3-button mode group
+        let modeGroup = findSubview(of: ModeButtonGroup.self, in: menuItem.view!)
+        XCTAssertNotNil(modeGroup)
+        let rangeContainer = rangeLabels[0].superview!
+        XCTAssertGreaterThanOrEqual(rangeContainer.frame.minX, modeGroup!.frame.maxX + 2,
+                                    "Range control overlaps the mode button group")
     }
 
     // MARK: - Protocol conformance tests


### PR DESCRIPTION
Closes #60, and covers the Eve Thermo case from #102.

## What this does

Temperature setpoints (thermostat target, heater-cooler heating and cooling thresholds, and Home Assistant climate targets) now step and display in the increment the device actually advertises, typically 0.5&nbsp;&deg;C, instead of hardcoded whole degrees. A 21.5&deg; setpoint set from Apple Home finally reads 21.5&deg; rather than 22&deg;, and the &plusmn; steppers can reach it.

It is metadata-driven, so it adapts per device: a 0.5&deg; radiator steps by 0.5&deg;, and a device that only reports whole degrees is completely unchanged.

In Celsius mode, a heat-mode setpoint of 21.5&deg; now displays `21.5&deg;` (previously `22&deg;`), one `+` click snaps it to `22&deg;`, and an Auto-mode range of 20.5&deg; / 24.5&deg; shows both halves in the widened labels. Fahrenheit is deliberately untouched: the same 21.5&nbsp;&deg;C setpoint still reads `71&deg;` and still steps one displayed degree per click (the #137 behaviour). Happy to attach rendered screenshots if useful.

## How it works

- **Metadata through the bridge.** `ServiceData` carries `step`/`min`/`max` for the target temperature and both thresholds, following the existing `rotationSpeedMin/Max` and `colorTemperatureMin/Max` precedent. On HomeKit they come from `HMCharacteristicMetadata` (`stepValue`/`minimumValue`/`maximumValue`); on Home Assistant from `target_temp_step`/`min_temp`/`max_temp`. HA values are normalized to internal Celsius, and because the step is a delta it scales by 5/9 without the freezing-point offset on Fahrenheit servers.
- **Sane UI step.** `TemperatureFormatter.uiStep` rounds the advertised step up to the nearest 0.5&nbsp;&deg;C. HomeKit's spec default step is 0.1&nbsp;&deg;C, which is unusable one click at a time, so 0.5 is the floor. Missing metadata falls back to 1.0, i.e. no behaviour change.
- **Grid-snap stepping.** In Celsius the value snaps to the step grid, so an off-grid 21.3 steps to 21.5 or 21.0. The Fahrenheit branch of `step` is untouched.
- **Honest display.** A new `formatSetpoint` shows one decimal only when the value is fractional (`21&deg;` vs `21.5&deg;`); the existing whole-degree `format` and its `ceil` are left exactly as they are, so sensor readouts and Fahrenheit are unaffected.
- **Metadata-driven clamps.** Setpoint clamps use the device min/max when present, with the previous constants (10/30, 16/30) as fallback. The 1&nbsp;&deg;C heat/cool spread is kept, since ecobee rejects writes with a smaller gap.
- **Bonus fix.** `ACMenuItem` stepped the raw Celsius value by 1 (1.8&nbsp;&deg;F per click), the same class of bug as #137 but never fixed for heater-coolers. It now goes through `TemperatureFormatter.step` like the other climate items, so Fahrenheit AC stepping moves one displayed degree.
- **Layout.** Auto-mode range labels widen to fit half-degree strings; mode buttons narrow slightly to keep the row inside its width budget.

## Tests

The suite goes from 987 to 1023 (36 added), all green on `xcodebuild test -scheme Itsyhome -destination "platform=macOS"`. Coverage includes the `uiStep` derivation table, Celsius grid-stepping and float-noise cases, `formatSetpoint` whole/half/negative, HA unit scaling, `ServiceData` codable round trips and legacy-JSON decode, and real label-text assertions through the menu-item views. The AC Fahrenheit fix and the new threshold-clamp behaviour are pinned with mutation-verified regression tests (reverting the fix makes them fail).

The three existing #137 Fahrenheit regression tests are byte-identical and still pass.

## Notes

- Half degrees are a Celsius-mode feature, matching the #60 request. Fahrenheit users keep whole-degree stepping and display by design.
- `HAClimateMenuItem` intentionally keeps its trailing margin, so its Auto layout differs slightly from the HomeKit items; noted in a comment.
- One pre-existing adjacent bug spotted but left untouched to keep the diff focused: HA scene target temperatures skip unit normalization (`EntityMapper` `generateSceneActions`), so on Fahrenheit servers the scene value is in &deg;F while everything else is Celsius. Happy to send that as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RGy77ui93iHqVnNLtrVWF
