### PR TITLE
fix: render sensor history sparkline in flipped coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Groups reorder anywhere in their room – a group row can be dragged among the room's accessories (previously groups were pinned to the top and a lone group couldn't be dragged at all), and every group and accessory row now shows a drag handle
 - Expand groups in Settings → Home – groups have a chevron revealing their member devices, and dragging those reorders the group. The group's submenu in the menu and its pinned menu-bar dropdown now follow that order instead of regrouping by type, and pinned room dropdowns follow the room's custom order too
 - Fix "Record sensor history" staying greyed out after buying Pro – the Advanced pane checked the Pro status only when it was first shown, so the toggle stayed disabled until the app was relaunched; it now unlocks the moment the purchase completes. The HomeKit bridge pane had the same stale gate (enable switch and upsell banner) and now rebuilds on Pro status changes like the other Pro panes
+- Fix sensor history chart drawn vertically mirrored – the numeric sparkline line rendered upside down (a rising reading drew a falling line, contradicting the hover readout) because SparklineView used AppKit's default non-flipped coordinate system while the y math assumes a flipped view (y = 0 at the top). SparklineView now overrides `isFlipped` so the line follows the data; the binary on/off timeline uses a symmetric mid-Y and is unchanged (#150, thanks @YuriNachos)
 
 ## 2.7.0
 

--- a/macOSBridge/History/SparklineView.swift
+++ b/macOSBridge/History/SparklineView.swift
@@ -142,6 +142,13 @@ final class SparklineView: NSView {
 
     // MARK: - Drawing
 
+    // numericPoints emits y in flipped coordinates (y = 0 at the top, max -> 0;
+    // min -> height), so flip this view to match. NSView's default isFlipped is
+    // false (y = 0 at the bottom), which mirrors every numeric series. The
+    // binary timeline is drawn around bounds.midY (symmetric), so flipping it
+    // is a no-op for its layout.
+    override var isFlipped: Bool { true }
+
     override func draw(_ dirtyRect: NSRect) {
         guard let series else { return }
         let since = referenceNow.addingTimeInterval(-(windowOverride ?? Self.window))

--- a/macOSBridgeTests/HistoryRenderingTests.swift
+++ b/macOSBridgeTests/HistoryRenderingTests.swift
@@ -131,6 +131,14 @@ final class HistoryRenderingTests: XCTestCase {
         XCTAssertEqual(v2.frame.width, 48)
     }
 
+    func testSparklineViewUsesFlippedCoordinateSystem() {
+        // HistoryRendering.numericPoints emits y in flipped coordinates
+        // (y = 0 at the top, max value -> 0; min value -> height), so the view
+        // must report isFlipped == true to draw the line the right way up.
+        // NSView's default is false, which mirrors every numeric series.
+        XCTAssertTrue(SparklineView(frame: .zero).isFlipped)
+    }
+
     // MARK: - Coverage gaps
 
     func testNumericPointRunsSplitAcrossUncoveredGap() {


### PR DESCRIPTION
<!-- Suggested title: fix: render sensor history sparkline in flipped coordinates -->

## Summary

The numeric sensor-history sparkline was rendered as its own **vertical mirror image**. `HistoryRendering.numericPoints` computes `y = height - normalized * height`, i.e. it emits coordinates in a **flipped** system (y = 0 at the top, the max value maps to y = 0 and the min to y = height). But `SparklineView` is a plain `NSView` whose default `isFlipped` is `false` (y = 0 at the bottom), so every numeric series was drawn upside-down — the curve shape contradicted the (correct) hover readout, which is built from the raw samples. Fixes #150.

The maintainer confirmed the fix in #150: *"Yes… `override var isFlipped: Bool { true }`"*.

## Root cause

`SparklineView` (`macOSBridge/History/SparklineView.swift`) had no `isFlipped` override. NSView's default is `false`, so the view's coordinate origin sat at the bottom-left while `numericPoints` assumed a top-left origin. `HistoryDetailView` embeds the same `SparklineView`, so both the inline sparkline and the detail chart were mirrored.

The **binary on/off timeline** is unaffected: it draws around `bounds.midY`, which is vertically symmetric, so flipping the coordinate system is a no-op for its layout.

## Changes

| File | Change |
| --- | --- |
| `macOSBridge/History/SparklineView.swift` | Add `override var isFlipped: Bool { true }` (with an explanatory comment) so the view matches `numericPoints`' flipped output. |
| `macOSBridgeTests/HistoryRenderingTests.swift` | New `testSparklineViewUsesFlippedCoordinateSystem` asserting `SparklineView(frame: .zero).isFlipped == true`, locking the invariant in. |
| `CHANGELOG.md` | Bullet under the unreleased section with `(thanks @YuriNachos)`. |

No math in `HistoryRendering.numericPoints` is touched — the computation is correct **given** a flipped view. No other view, no localization, no other coordinate path.

## Test plan

- [x] New `testSparklineViewUsesFlippedCoordinateSystem` passes (it documents the previously-missing override).
- [x] `xcodebuild test -scheme Itsyhome -destination 'platform=macOS' -only-testing:macOSBridgeTests/HistoryRenderingTests CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO` → all `HistoryRenderingTests` pass.
- [x] The binary-timeline tests in the same suite still pass (flipping is a no-op there, as intended).

Red-before-green: on `main`, `SparklineView(frame: .zero).isFlipped` is `false`, so the new assertion fails; after the override it is `true`.

Fixes #150.