### PR TITLE
fix: average group-light hue as a circular mean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Groups reorder anywhere in their room – a group row can be dragged among the room's accessories (previously groups were pinned to the top and a lone group couldn't be dragged at all), and every group and accessory row now shows a drag handle
 - Expand groups in Settings → Home – groups have a chevron revealing their member devices, and dragging those reorders the group. The group's submenu in the menu and its pinned menu-bar dropdown now follow that order instead of regrouping by type, and pinned room dropdowns follow the room's custom order too
 - Fix "Record sensor history" staying greyed out after buying Pro – the Advanced pane checked the Pro status only when it was first shown, so the toggle stayed disabled until the app was relaunched; it now unlocks the moment the purchase completes. The HomeKit bridge pane had the same stale gate (enable switch and upsell banner) and now rebuilds on Pro status changes like the other Pro panes
+- Fix the group colour swatch showing the wrong hue for lights clustered near red – the group's average hue was a plain arithmetic mean of degrees, so two lights at 350° and 10° (both near red) averaged to 180° (cyan). Hue is now averaged as an angle (mean of unit vectors, recovered with atan2), so colours blend correctly across the 0°/360° boundary while ordinary same-area clusters are unchanged (thanks @YuriNachos)
 
 ## 2.7.0
 

--- a/macOSBridge/MenuItems/GroupMenuItem+StateManagement.swift
+++ b/macOSBridge/MenuItems/GroupMenuItem+StateManagement.swift
@@ -116,7 +116,9 @@ extension GroupMenuItem {
             currentBrightness = brightnessStates.values.reduce(0, +) / Double(brightnessStates.count)
         }
         if !hueStates.isEmpty {
-            currentHue = hueStates.values.reduce(0, +) / Double(hueStates.count)
+            // Hue is an angle: use the circular mean so lights around the 0°/360°
+            // boundary (e.g. 350° and 10°) average to red (~0°), not cyan (~180°).
+            currentHue = HueMath.circularMean(of: Array(hueStates.values))
         }
         if !saturationStates.isEmpty {
             currentSaturation = saturationStates.values.reduce(0, +) / Double(saturationStates.count)
@@ -207,7 +209,7 @@ extension GroupMenuItem {
     private func handleHueUpdate(characteristicId: UUID, value: Any) {
         if let newHue = ValueConversion.toDouble(value) {
             hueStates[characteristicId] = newHue
-            currentHue = hueStates.values.reduce(0, +) / Double(hueStates.count)
+            currentHue = HueMath.circularMean(of: Array(hueStates.values))
             lastColorSource = "rgb"
             updateSliderColor()
             (colorPickerView as? ColorWheelPickerView)?.updateColor(hue: currentHue, saturation: currentSaturation)

--- a/macOSBridge/MenuItems/HueMath.swift
+++ b/macOSBridge/MenuItems/HueMath.swift
@@ -1,0 +1,35 @@
+//
+//  HueMath.swift
+//  macOSBridge
+//
+//  Circular (angular) mean for averaging group-light hue values.
+//
+
+import Foundation
+
+enum HueMath {
+
+    /// Circular (angular) mean of hue values given in degrees.
+    ///
+    /// Hue lives on a wheel, so an arithmetic mean is wrong at the 0°/360°
+    /// boundary — 350° and 10° are both near red but average to 180° (cyan).
+    /// Converting each hue to a unit vector, averaging the vectors, and
+    /// recovering the angle with `atan2` yields the perceptually correct
+    /// ~0° (red). Result is normalized to [0, 360). When the vectors cancel
+    /// out (e.g. evenly spaced 0°/120°/240°) the direction is undefined; the
+    /// result stays finite and in range rather than becoming NaN.
+    static func circularMean(of hues: [Double]) -> Double {
+        guard !hues.isEmpty else { return 0 }
+        var sumSin: Double = 0
+        var sumCos: Double = 0
+        for hue in hues {
+            let radians = hue * .pi / 180
+            sumSin += sin(radians)
+            sumCos += cos(radians)
+        }
+        let count = Double(hues.count)
+        let meanDegrees = atan2(sumSin / count, sumCos / count) * 180 / .pi
+        // atan2 returns [-180, 180]; normalize to [0, 360).
+        return meanDegrees < 0 ? meanDegrees + 360 : meanDegrees
+    }
+}

--- a/macOSBridgeTests/HueMathTests.swift
+++ b/macOSBridgeTests/HueMathTests.swift
@@ -1,0 +1,89 @@
+//
+//  HueMathTests.swift
+//  macOSBridgeTests
+//
+//  Regression tests for the circular (angular) mean used to average group-light
+//  hue. Hue is an angle on a wheel, so an arithmetic mean is wrong at the
+//  0°/360° boundary: lights at 350° and 10° are both near red, yet their
+//  arithmetic mean is 180° (cyan). The circular mean recovers ~0° (red).
+//
+//  Because hue is circular, 0° and 360° name the same point. Floating-point
+//  noise at that boundary can yield either ~0° or ~359.9999°, so hue results
+//  are compared by the shortest angular distance around the wheel, not by
+//  direct equality.
+//
+
+import XCTest
+@testable import macOSBridge
+
+final class HueMathTests: XCTestCase {
+
+    /// Shortest angular distance between two hues, in [0, 180].
+    private func circularDistance(_ a: Double, _ b: Double) -> Double {
+        let raw = abs(a - b).truncatingRemainder(dividingBy: 360)
+        return raw > 180 ? 360 - raw : raw
+    }
+
+    // MARK: - Wraparound across the 0°/360° boundary (the bug)
+
+    func testCircularMeanAcrossZeroBoundaryIsRedNotCyan() {
+        // Arithmetic mean of 350 and 10 is 180° (cyan) — the failure this fixes.
+        let arithmetic = [350.0, 10.0].reduce(0, +) / 2
+        XCTAssertEqual(arithmetic, 180, accuracy: 0.001)
+
+        // Circular mean lands at ~0° (red), the perceptually correct average.
+        let mean = HueMath.circularMean(of: [350, 10])
+        XCTAssertLessThanOrEqual(circularDistance(mean, 0), 1.0,
+                                 "expected ~0° (red), got \(mean)°")
+    }
+
+    func testCircularMeanOf359And1IsNearZero() {
+        let mean = HueMath.circularMean(of: [359, 1])
+        XCTAssertLessThanOrEqual(circularDistance(mean, 0), 1.0,
+                                 "expected ~0° (red), got \(mean)°")
+    }
+
+    func testCircularMeanOfThreeValueWraparoundCluster() {
+        // A group usually holds more than two bulbs — exercise the multi-element
+        // path across the 0°/360° seam. Cluster is symmetric around red → ~0°.
+        let mean = HueMath.circularMean(of: [350, 0, 10])
+        XCTAssertLessThanOrEqual(circularDistance(mean, 0), 1.0,
+                                 "expected ~0° (red), got \(mean)°")
+    }
+
+    // MARK: - Non-wraparound clusters match the arithmetic mean (no regression)
+
+    func testNonWrappingClusterMatchesArithmetic() {
+        let hues = [10.0, 20.0, 30.0]
+        let arithmetic = hues.reduce(0, +) / Double(hues.count)
+        let mean = HueMath.circularMean(of: hues)
+        XCTAssertLessThanOrEqual(circularDistance(mean, arithmetic), 0.5,
+                                 "expected ~\(arithmetic)°, got \(mean)°")
+    }
+
+    func testTwoCloseHuesAverageToMidpoint() {
+        // 40° and 60° average to 50° under both means.
+        let mean = HueMath.circularMean(of: [40, 60])
+        XCTAssertLessThanOrEqual(circularDistance(mean, 50), 1.0,
+                                 "expected ~50°, got \(mean)°")
+    }
+
+    // MARK: - Edge cases
+
+    func testEmptyReturnsZero() {
+        XCTAssertEqual(HueMath.circularMean(of: []), 0, accuracy: 0.001)
+    }
+
+    func testSingleValueReturnsItself() {
+        XCTAssertEqual(HueMath.circularMean(of: [137]), 137, accuracy: 0.001)
+    }
+
+    func testEvenlySpacedHuesAreFiniteInRange() {
+        // 0°/120°/240° cancel out (mean vector ~origin); the result is undefined
+        // in direction but must be finite and within [0, 360).
+        let mean = HueMath.circularMean(of: [0, 120, 240])
+        XCTAssertTrue(mean.isFinite)
+        XCTAssertGreaterThanOrEqual(mean, 0)
+        XCTAssertLessThan(mean, 360)
+    }
+}


### PR DESCRIPTION
## Summary

Group colour controls averaged hue with a plain arithmetic mean of degrees. Because hue is an angle on a wheel, that breaks at the 0°/360° boundary: two lights at 350° and 10° (both near red) averaged to 180° (cyan), so a light group spanning red showed the wrong colour. Hue is now averaged as an angle — each value converted to a unit vector, the vectors averaged, and the angle recovered with `atan2` (a circular mean). Non-wraparound clusters are unchanged, since the circular mean matches the arithmetic mean away from the boundary.

## Why this matters

Hue is circular, not linear. Averaging 350° and 10° linearly gives 180° (cyan) even though both lights are red — the arithmetic mean routes through the wrong side of the circle. The circular mean averages the lights' unit vectors and recovers the direction, giving ~0° (red), the colour the group actually looks. This is the standard way to average angles; it only differs from the old behaviour for groups whose hues straddle the 0°/360° seam.

Extracted as a small pure helper `HueMath.circularMean(of:)` and used at both sites that recompute the group hue (initial average and live characteristic update). Saturation, brightness and colour-temperature averaging are untouched.

## Testing

- `xcodegen generate && xcodebuild test -scheme Itsyhome -destination "platform=macOS" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- New `macOSBridgeTests/HueMathTests` (8 cases): the two boundary cases (`[350,10]` and `[359,1]`) fail at 180° against the old arithmetic mean and pass at ~0° with the circular mean; a 3-value wraparound cluster (`[350,0,10]`), non-wraparound clusters (`[10,20,30]`, `[40,60]`), and edge cases (empty, single, antipodal cancellation `[0,120,240]`) are covered.
- Full suite green: **995 tests, 0 failures**.
- Not exercised: on-device run / real multi-light HomeKit group (no hardware in this environment). The change is scoped to the in-memory hue average and is fully covered by the headless unit test.