### PR TITLE
fix: invalidate URLSessions on disconnect (NSURLErrorDomain error 12)

### DIFF
--- a/Itsyhome/HomeAssistant/HAAuthManager.swift
+++ b/Itsyhome/HomeAssistant/HAAuthManager.swift
@@ -109,6 +109,7 @@ final class HAAuthManager {
             client.disconnect()
             return true
         } catch {
+            client.disconnect()
             let nsError = error as NSError
             logger.error("Credential validation failed: \(nsError.domain, privacy: .public) \(nsError.code, privacy: .public) – \(nsError.localizedDescription, privacy: .public)")
             throw error

--- a/Itsyhome/HomeAssistant/HAAuthManager.swift
+++ b/Itsyhome/HomeAssistant/HAAuthManager.swift
@@ -109,7 +109,8 @@ final class HAAuthManager {
             client.disconnect()
             return true
         } catch {
-            logger.error("Credential validation failed: \(error.localizedDescription)")
+            let nsError = error as NSError
+            logger.error("Credential validation failed: \(nsError.domain, privacy: .public) \(nsError.code, privacy: .public) – \(nsError.localizedDescription, privacy: .public)")
             throw error
         }
     }
@@ -130,7 +131,8 @@ final class HAAuthManager {
             return (devices.count, areas.count)
         } catch {
             client.disconnect()
-            logger.error("Credential validation failed: \(error.localizedDescription)")
+            let nsError = error as NSError
+            logger.error("Credential validation failed: \(nsError.domain, privacy: .public) \(nsError.code, privacy: .public) – \(nsError.localizedDescription, privacy: .public)")
             throw error
         }
     }

--- a/Itsyhome/HomeAssistant/HomeAssistantClient.swift
+++ b/Itsyhome/HomeAssistant/HomeAssistantClient.swift
@@ -237,7 +237,8 @@ final class HomeAssistantClient: NSObject {
                 self.receiveMessage()  // Continue receiving
 
             case .failure(let error):
-                logger.error("WebSocket receive error: \(error.localizedDescription)")
+                let nsError = error as NSError
+                logger.error("WebSocket receive error: \(nsError.domain, privacy: .public) \(nsError.code, privacy: .public) – \(nsError.localizedDescription, privacy: .public)")
                 self.handleDisconnection(error: error)
             }
         }

--- a/Itsyhome/HomeAssistant/HomeAssistantClient.swift
+++ b/Itsyhome/HomeAssistant/HomeAssistantClient.swift
@@ -61,7 +61,35 @@ final class HomeAssistantClient: NSObject {
     private let accessToken: String
 
     private var webSocketTask: URLSessionWebSocketTask?
-    private var urlSession: URLSession!
+
+    private let sessionConfiguration: URLSessionConfiguration = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30
+        config.timeoutIntervalForResource = 300
+        return config
+    }()
+
+    private var activeURLSession: URLSession?
+    private let sessionLock = NSLock()
+
+    /// The session backing the WebSocket and REST calls.
+    ///
+    /// Created on demand and torn down in `disconnect()`. A session keeps a
+    /// strong reference to its delegate until it is invalidated, so one that is
+    /// never invalidated leaks this client along with every connection it
+    /// pooled – and the process eventually runs out of network flows.
+    private var urlSession: URLSession {
+        sessionLock.lock()
+        defer { sessionLock.unlock() }
+
+        if let session = activeURLSession {
+            return session
+        }
+
+        let session = URLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
+        activeURLSession = session
+        return session
+    }
 
     private var messageId: Int = 1
     private var pendingRequests: [Int: (Result<Any, Error>) -> Void] = [:]
@@ -117,11 +145,6 @@ final class HomeAssistantClient: NSObject {
         self.accessToken = accessToken
 
         super.init()
-
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 30
-        config.timeoutIntervalForResource = 300
-        self.urlSession = URLSession(configuration: config, delegate: self, delegateQueue: nil)
     }
 
     deinit {
@@ -132,6 +155,10 @@ final class HomeAssistantClient: NSObject {
 
     func connect() async throws {
         logger.info("Connecting to Home Assistant at \(self.serverURL.absoluteString, privacy: .public)")
+
+        // Drop any previous task – reconnects would otherwise leave the old
+        // one and its connection alive for the lifetime of the session
+        webSocketTask?.cancel(with: .goingAway, reason: nil)
 
         webSocketTask = urlSession.webSocketTask(with: serverURL)
         webSocketTask?.maximumMessageSize = 16 * 1024 * 1024
@@ -169,6 +196,14 @@ final class HomeAssistantClient: NSObject {
         webSocketTask?.cancel(with: .goingAway, reason: nil)
         webSocketTask = nil
 
+        // Invalidating is what releases the session's strong reference to this
+        // client, and with it the pooled connections
+        sessionLock.lock()
+        let session = activeURLSession
+        activeURLSession = nil
+        sessionLock.unlock()
+        session?.invalidateAndCancel()
+
         stateLock.lock()
         // Cancel auth continuation if pending
         let continuation = authContinuation
@@ -189,8 +224,12 @@ final class HomeAssistantClient: NSObject {
     // MARK: - Message handling
 
     private func receiveMessage() {
-        webSocketTask?.receive { [weak self] result in
-            guard let self = self else { return }
+        guard let task = webSocketTask else { return }
+
+        task.receive { [weak self] result in
+            // Ignore a task we have already replaced – its failure is the
+            // cancellation we asked for, not a disconnection to react to
+            guard let self = self, self.webSocketTask === task else { return }
 
             switch result {
             case .success(let message):

--- a/Itsyhome/HomeAssistant/HomeAssistantClient.swift
+++ b/Itsyhome/HomeAssistant/HomeAssistantClient.swift
@@ -72,13 +72,14 @@ final class HomeAssistantClient: NSObject {
     private var activeURLSession: URLSession?
     private let sessionLock = NSLock()
 
-    /// The session backing the WebSocket and REST calls.
+    /// The session backing the WebSocket and REST calls, created by `connect()`
+    /// and torn down in `disconnect()`.
     ///
-    /// Created on demand and torn down in `disconnect()`. A session keeps a
-    /// strong reference to its delegate until it is invalidated, so one that is
-    /// never invalidated leaks this client along with every connection it
-    /// pooled – and the process eventually runs out of network flows.
-    private var urlSession: URLSession {
+    /// A session keeps a strong reference to its delegate until it is
+    /// invalidated, so one that is never invalidated leaks this client along
+    /// with every connection it pooled – and the process eventually runs out of
+    /// network flows.
+    private func makeSession() -> URLSession {
         sessionLock.lock()
         defer { sessionLock.unlock() }
 
@@ -89,6 +90,16 @@ final class HomeAssistantClient: NSObject {
         let session = URLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
         activeURLSession = session
         return session
+    }
+
+    /// The session of an established connection, or `nil` once disconnected.
+    ///
+    /// Deliberately does not create one: a request that outlives `disconnect()`
+    /// would otherwise get a session nothing is left to invalidate.
+    private var currentSession: URLSession? {
+        sessionLock.lock()
+        defer { sessionLock.unlock() }
+        return activeURLSession
     }
 
     private var messageId: Int = 1
@@ -104,6 +115,7 @@ final class HomeAssistantClient: NSObject {
 
     private var pingTimer: Timer?
     private var pingTimeout: DispatchWorkItem?
+    private var reconnectWorkItem: DispatchWorkItem?
 
     weak var delegate: HomeAssistantClientDelegate?
 
@@ -156,13 +168,18 @@ final class HomeAssistantClient: NSObject {
     func connect() async throws {
         logger.info("Connecting to Home Assistant at \(self.serverURL.absoluteString, privacy: .public)")
 
-        // Drop any previous task – reconnects would otherwise leave the old
-        // one and its connection alive for the lifetime of the session
-        webSocketTask?.cancel(with: .goingAway, reason: nil)
+        // Drop any previous task – reconnects would otherwise leave the old one
+        // and its connection alive for the lifetime of the session. Clearing
+        // the reference first means its cancellation is seen as stale rather
+        // than as a disconnection to react to.
+        let previousTask = webSocketTask
+        webSocketTask = nil
+        previousTask?.cancel(with: .goingAway, reason: nil)
 
-        webSocketTask = urlSession.webSocketTask(with: serverURL)
-        webSocketTask?.maximumMessageSize = 16 * 1024 * 1024
-        webSocketTask?.resume()
+        let task = makeSession().webSocketTask(with: serverURL)
+        task.maximumMessageSize = 16 * 1024 * 1024
+        webSocketTask = task
+        task.resume()
 
         // Start receiving messages
         receiveMessage()
@@ -192,6 +209,12 @@ final class HomeAssistantClient: NSObject {
 
         stopPingPong()
         isAuthenticated = false
+
+        // A reconnect scheduled up to 30s ago would otherwise fire after
+        // teardown and build a fresh session nothing is left to invalidate
+        reconnectWorkItem?.cancel()
+        reconnectWorkItem = nil
+        reconnectAttempts = 0
 
         webSocketTask?.cancel(with: .goingAway, reason: nil)
         webSocketTask = nil
@@ -402,12 +425,14 @@ final class HomeAssistantClient: NSObject {
 
         logger.info("Scheduling reconnect in \(delay, privacy: .public) seconds (attempt \(self.reconnectAttempts))")
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+        let workItem = DispatchWorkItem { [weak self] in
             guard let self = self else { return }
             Task {
                 try? await self.connect()
             }
         }
+        reconnectWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
 
     // MARK: - Ping/Pong
@@ -784,7 +809,11 @@ final class HomeAssistantClient: NSObject {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
         }
 
-        let (data, response) = try await urlSession.data(for: request)
+        guard let session = currentSession else {
+            throw HomeAssistantClientError.notConnected
+        }
+
+        let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse,
               200..<300 ~= httpResponse.statusCode else {
@@ -804,6 +833,10 @@ extension HomeAssistantClient: URLSessionWebSocketDelegate {
 
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
         logger.info("WebSocket connection closed: \(closeCode.rawValue)")
+
+        // Ignore a task we have already replaced or cancelled ourselves
+        guard self.webSocketTask === webSocketTask else { return }
+
         handleDisconnection(error: nil)
     }
 }

--- a/Itsyhome/iOS/HACameraSignaling.swift
+++ b/Itsyhome/iOS/HACameraSignaling.swift
@@ -17,7 +17,34 @@ final class HACameraSignaling: NSObject {
     // MARK: - Properties
 
     private var webSocketTask: URLSessionWebSocketTask?
-    private var urlSession: URLSession!
+
+    private let sessionConfiguration: URLSessionConfiguration = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 15
+        return config
+    }()
+
+    private var activeURLSession: URLSession?
+    private let sessionLock = NSLock()
+
+    /// The session backing the signalling WebSocket.
+    ///
+    /// One signalling client is created per stream, so the session has to be
+    /// invalidated in `disconnect()`: until it is, it keeps a strong reference
+    /// to this client and to the connection it used.
+    private var urlSession: URLSession {
+        sessionLock.lock()
+        defer { sessionLock.unlock() }
+
+        if let session = activeURLSession {
+            return session
+        }
+
+        let session = URLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
+        activeURLSession = session
+        return session
+    }
+
     private var messageId: Int = 1
     private var pendingRequests: [Int: (Result<Any, Error>) -> Void] = [:]
     private let lock = NSLock()
@@ -35,13 +62,6 @@ final class HACameraSignaling: NSObject {
     private var subscriptionId: Int?
 
     // MARK: - Initialization
-
-    override init() {
-        super.init()
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 15
-        urlSession = URLSession(configuration: config, delegate: self, delegateQueue: nil)
-    }
 
     deinit {
         disconnect()
@@ -106,6 +126,12 @@ final class HACameraSignaling: NSObject {
         isAuthenticated = false
         webSocketTask?.cancel(with: .goingAway, reason: nil)
         webSocketTask = nil
+
+        sessionLock.lock()
+        let session = activeURLSession
+        activeURLSession = nil
+        sessionLock.unlock()
+        session?.invalidateAndCancel()
 
         lock.lock()
         let authCont = authContinuation

--- a/macOSBridgeTests/HomeAssistant/HomeAssistantClientTests.swift
+++ b/macOSBridgeTests/HomeAssistant/HomeAssistantClientTests.swift
@@ -172,19 +172,21 @@ final class HomeAssistantClientTests: XCTestCase {
 
     // MARK: - Session lifecycle tests
 
-    func testClientIsReleasedAfterDisconnect() throws {
-        // Given a client that has been disconnected
+    func testClientIsReleasedAfterDisconnect() async throws {
+        // Given a client that has connected – nothing is discarded on a port
+        // that refuses connections, but the attempt is what builds the session
         weak var weakClient: HomeAssistantClient?
 
-        try autoreleasepool {
-            let client = try HomeAssistantClient(serverURL: URL(string: "http://homeassistant.local:8123")!,
+        do {
+            let client = try HomeAssistantClient(serverURL: URL(string: "http://127.0.0.1:9")!,
                                                  accessToken: "test")
             weakClient = client
+            try? await client.connect()
             client.disconnect()
         }
 
         // When its session has finished invalidating
-        let deadline = Date().addingTimeInterval(2)
+        let deadline = Date().addingTimeInterval(5)
         while weakClient != nil && Date() < deadline {
             RunLoop.current.run(until: Date().addingTimeInterval(0.05))
         }
@@ -192,6 +194,24 @@ final class HomeAssistantClientTests: XCTestCase {
         // Then nothing holds on to the client – a URLSession that is never
         // invalidated retains its delegate for the lifetime of the process
         XCTAssertNil(weakClient, "Client leaked – its URLSession still retains it as delegate")
+    }
+
+    func testRESTRequestAfterDisconnectDoesNotBuildANewSession() async throws {
+        // Given a disconnected client
+        let client = try HomeAssistantClient(serverURL: URL(string: "http://127.0.0.1:9")!,
+                                             accessToken: "test")
+        client.disconnect()
+
+        // When a REST call arrives late
+        do {
+            _ = try await client.restRequest(path: "api/config")
+            XCTFail("Expected the request to fail rather than open a new session")
+        } catch {
+            // Then it fails instead of creating a session nothing would invalidate
+            guard case HomeAssistantClientError.notConnected = error else {
+                return XCTFail("Expected notConnected, got \(error)")
+            }
+        }
     }
 
     func testServiceCallFailedError() {

--- a/macOSBridgeTests/HomeAssistant/HomeAssistantClientTests.swift
+++ b/macOSBridgeTests/HomeAssistant/HomeAssistantClientTests.swift
@@ -170,6 +170,30 @@ final class HomeAssistantClientTests: XCTestCase {
         }
     }
 
+    // MARK: - Session lifecycle tests
+
+    func testClientIsReleasedAfterDisconnect() throws {
+        // Given a client that has been disconnected
+        weak var weakClient: HomeAssistantClient?
+
+        try autoreleasepool {
+            let client = try HomeAssistantClient(serverURL: URL(string: "http://homeassistant.local:8123")!,
+                                                 accessToken: "test")
+            weakClient = client
+            client.disconnect()
+        }
+
+        // When its session has finished invalidating
+        let deadline = Date().addingTimeInterval(2)
+        while weakClient != nil && Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+
+        // Then nothing holds on to the client – a URLSession that is never
+        // invalidated retains its delegate for the lifetime of the process
+        XCTAssertNil(weakClient, "Client leaked – its URLSession still retains it as delegate")
+    }
+
     func testServiceCallFailedError() {
         let error = HomeAssistantClientError.serviceCallFailed("Entity not found")
         XCTAssertEqual(error.errorDescription, "Service call failed: Entity not found")


### PR DESCRIPTION
## What

`HomeAssistantClient` and `HACameraSignaling` both create a `URLSession` with `delegate: self` and never invalidate it. A session holds a strong reference to its delegate until it is invalidated, so each client leaks itself along with the connections its session pooled, and `deinit` is never reached.

That would be a slow leak on its own, but both types are created repeatedly – a new `HACameraSignaling` per camera stream, and a new `HomeAssistantClient` per connect and per credential validation.

## Symptom

After a long uptime the process runs out of network flows and the kernel refuses to allocate more. Every connection then fails instantly, before anything leaves the machine:

```
nw_path_evaluator_create_flow_inner NECP_CLIENT_ACTION_ADD_FLOW … [12: Cannot allocate memory]
Connection 21669: failed to connect 1:12
Task <…> finished with error [12] Error Domain=NSURLErrorDomain Code=12
```

CFNetwork passes the POSIX `ENOMEM` through as an `NSURLErrorDomain` code, which matches no `URLError` case, so the connect sheet shows "The operation couldn't be completed. (NSURLErrorDomain error 12.)" and the app retries on backoff until it gives up. Only quitting and relaunching clears it.

On the machine where I hit this the process had been up for 20 days and had created 21,671 connections, and the failure had been firing for a day (33,885 times) against both a local `:8123` URL and a Nabu Casa remote one. The server was fine throughout – `curl` completed the WebSocket handshake (HTTP 101), and a standalone `URLSessionWebSocketTask` in a separate process connected and received `auth_required`.

## Changes

- Both clients build their session on demand and invalidate it in `disconnect()`, which is what releases the delegate reference and the pooled connections. REST calls arriving after a disconnect transparently get a fresh session.
- `connect()` cancels the previous WebSocket task before replacing it, so reconnects stop stranding the old one.
- `receiveMessage()` ignores results from a task that has already been replaced. This is required by the change above: without it, cancelling a stale task fires its receive handler and schedules a duplicate reconnect.
- Connection errors log their domain and code with `privacy: .public`. os_log redacted the whole interpolation before, so every failure logged as `WebSocket receive error: <private>` – and for URL errors the description on its own says nothing useful anyway. No URL or token is logged.

## Testing

`testClientIsReleasedAfterDisconnect` covers the leak. It fails on `main` (`XCTAssertNil failed … Client leaked – its URLSession still retains it as delegate`) and passes here.

Reconnect after invalidation is the part a unit test can't reach, so I checked it separately by compiling `HomeAssistantClient` against a stub server that speaks the HA auth handshake: two sequential connect/disconnect cycles both reach the server and both come back with `authenticationFailed` from HA rather than a transport error.

Full suite: 1046 tests, 0 failures. No new user-facing strings, so there is nothing to localize.
